### PR TITLE
Align newResourceCollection argument with documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added ability to pass an array of records to ResourcefulEndpoint.newResourceCollection()
+* Deprecated passing an object with pluralName to ResourcefulEndpoint.newResourceCollection()
+
 ## 1.6.0
 
 * Add ability to specify a batchSize when calling ResourceCollection.save()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.7.0
+
 * Added ability to pass an array of records to ResourcefulEndpoint.newResourceCollection()
 * Deprecated passing an object with pluralName to ResourcefulEndpoint.newResourceCollection()
 

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -274,9 +274,13 @@ class ResourceCollection {
     const batchSize = size !== undefined ? size : this.resourcefulEndpoint.batchSize;
     const numberOfPages = Math.ceil(this.totalCount / batchSize);
 
-    return Array.from(new Array(numberOfPages), (x, i) =>
-      this.resourcefulEndpoint.newResourceCollection(
-        this.collection.slice(i * batchSize, (i * batchSize) + batchSize).map(r => r.toJSON())));
+    return Array.from(
+      new Array(numberOfPages),
+      (x, i) => this.resourcefulEndpoint.newResourceCollection(this.collection.slice(
+        i * batchSize,
+        (i * batchSize) + batchSize
+      ).map(r => r.toJSON()))
+    );
   }
 
   /**

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -274,9 +274,9 @@ class ResourceCollection {
     const batchSize = size !== undefined ? size : this.resourcefulEndpoint.batchSize;
     const numberOfPages = Math.ceil(this.totalCount / batchSize);
 
-    return Array.from(new Array(numberOfPages), (x, i) => this.resourcefulEndpoint.newResourceCollection({
-      [this.resourcefulEndpoint.pluralName]: this.collection.slice(i * batchSize, (i * batchSize) + batchSize).map(r => r.toJSON())
-    }));
+    return Array.from(new Array(numberOfPages), (x, i) =>
+      this.resourcefulEndpoint.newResourceCollection(
+        this.collection.slice(i * batchSize, (i * batchSize) + batchSize).map(r => r.toJSON())));
   }
 
   /**

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -185,9 +185,18 @@ class ResourcefulEndpoint {
   newResourceCollection(data = []) {
     const { pluralName } = this.resourceful;
 
-    return new ResourceCollection({
-      [pluralName]: data
-    }, '', this);
+    let collectionData;
+
+    if (Array.isArray(data)) {
+      collectionData = {
+        [pluralName]: data
+      };
+    } else {
+      collectionData = data;
+      console.warn('Using newResourceCollection with an object is deprecated - pass an array instead');
+    }
+
+    return new ResourceCollection(collectionData, '', this);
   }
 
   /**

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -182,8 +182,12 @@ class ResourcefulEndpoint {
    *
    * @returns {ResourceCollection}
    */
-  newResourceCollection(data) {
-    return new ResourceCollection(data, '', this);
+  newResourceCollection(data = []) {
+    const { pluralName } = this.resourceful;
+
+    return new ResourceCollection({
+      [pluralName]: data
+    }, '', this);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Sequoia client SDK for Javascript",
   "main": "dist/web/sequoia-client.js",
   "scripts": {

--- a/test/spec/resourceful_endpoint.js
+++ b/test/spec/resourceful_endpoint.js
@@ -133,6 +133,25 @@ describe('ResourcefulEndpoint', () => {
         new Resource({ name: 'bar' }, resourcefulEndpoint)
       ]);
     });
+
+    it('should take an object but issue a deprecation warning', () => {
+      jest.spyOn(console, 'warn');
+
+      const collection = resourcefulEndpoint.newResourceCollection({
+        [resourcefulEndpoint.resourceful.pluralName]: [
+          { name: 'foo' },
+          { name: 'bar' }
+        ]
+      });
+
+      expect(collection.collection).toEqual([
+        new Resource({ name: 'foo' }, resourcefulEndpoint),
+        new Resource({ name: 'bar' }, resourcefulEndpoint)
+      ]);
+
+      expect(console.warn)
+        .toHaveBeenCalledWith('Using newResourceCollection with an object is deprecated - pass an array instead');
+    });
   });
 
   describe('relationships', () => {

--- a/test/spec/resourceful_endpoint.js
+++ b/test/spec/resourceful_endpoint.js
@@ -121,6 +121,18 @@ describe('ResourcefulEndpoint', () => {
     it('should return a new Resource instance', () => {
       expect(resourcefulEndpoint.newResourceCollection() instanceof ResourceCollection).toBe(true);
     });
+
+    it('should take an array of items', () => {
+      const collection = resourcefulEndpoint.newResourceCollection([
+        { name: 'foo' },
+        { name: 'bar' }
+      ]);
+
+      expect(collection.collection).toEqual([
+        new Resource({ name: 'foo' }, resourcefulEndpoint),
+        new Resource({ name: 'bar' }, resourcefulEndpoint)
+      ]);
+    });
   });
 
   describe('relationships', () => {


### PR DESCRIPTION
- newResourceCollection used to take an object where the key was the resources pluralName
- newResourceCollection now takes an array of items, and pluralName is derived from the resourceful endpoint
- Added a UT to assert this

**Old usage:**
```javascript
resourceful.newResourceCollection({
  [resourceful.resourceful.pluralName]: [{ name: 'foo' }]
});
```

**New usage:**
```javascript
resourceful.newResourceCollection([{ name: 'foo' }]);
```
This is how the docs described it, and it makes more sense to me than needing to supply the pluralName when it's already stored on the resourceful endpoint object.