### PR TITLE
remove reliance on deprecated mediaType prop

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -482,9 +482,9 @@ class Resource {
   // Convenience methods:
   // TODO: these should be rolled into an optional mixin
   /* istanbul ignore next */
-  getLinkedAssetOfType(mediaType) {
+  getLinkedAssetOfType(type) {
     if (this.hasLinked('assets')) {
-      return this.linked.assets.filter(item => item.mediaType === mediaType);
+      return this.linked.assets.filter(item => item.type === type);
     }
 
     return [];

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -424,7 +424,7 @@ class ResourcefulEndpoint {
    *       "ref",
    *       "name",
    *       "contentRef",
-   *       "mediaType",
+   *       "type",
    *       "url",
    *       "fileFormat",
    *       "title",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,9 +19,9 @@
       "integrity": "sha1-7ySTFDLwYVXnvDnNuKaze0oos9A=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -30,7 +30,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -39,9 +39,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -50,7 +50,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -70,8 +70,8 @@
         "@webassemblyjs/helper-module-context": "1.5.13",
         "@webassemblyjs/helper-wasm-bytecode": "1.5.13",
         "@webassemblyjs/wast-parser": "1.5.13",
-        "debug": "3.1.0",
-        "mamacro": "0.0.3"
+        "debug": "^3.1.0",
+        "mamacro": "^0.0.3"
       },
       "dependencies": {
         "debug": {
@@ -103,7 +103,7 @@
       "integrity": "sha512-v7igWf1mHcpJNbn4m7e77XOAWXCDT76Xe7Is1VQFXc4K5jRcFrl9D0NrqM4XifQ0bXiuTSkTKMYqDxu5MhNljA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -138,8 +138,8 @@
       "integrity": "sha512-zxJXULGPLB7r+k+wIlvGlXpT4CYppRz8fLUM/xobGHc9Z3T6qlmJD9ySJ2jknuktuuiR9AjnNpKYDECyaiX+QQ==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "mamacro": "0.0.3"
+        "debug": "^3.1.0",
+        "mamacro": "^0.0.3"
       },
       "dependencies": {
         "debug": {
@@ -169,7 +169,7 @@
         "@webassemblyjs/helper-buffer": "1.5.13",
         "@webassemblyjs/helper-wasm-bytecode": "1.5.13",
         "@webassemblyjs/wasm-gen": "1.5.13",
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -189,7 +189,7 @@
       "integrity": "sha512-TseswvXEPpG5TCBKoLx9tT7+/GMACjC1ruo09j46ULRZWYm8XHpDWaosOjTnI7kr4SRJFzA6MWoUkAB+YCGKKg==",
       "dev": true,
       "requires": {
-        "ieee754": "1.1.12"
+        "ieee754": "^1.1.11"
       }
     },
     "@webassemblyjs/leb128": {
@@ -229,7 +229,7 @@
         "@webassemblyjs/wasm-opt": "1.5.13",
         "@webassemblyjs/wasm-parser": "1.5.13",
         "@webassemblyjs/wast-printer": "1.5.13",
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -266,7 +266,7 @@
         "@webassemblyjs/helper-buffer": "1.5.13",
         "@webassemblyjs/wasm-gen": "1.5.13",
         "@webassemblyjs/wasm-parser": "1.5.13",
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -305,8 +305,8 @@
         "@webassemblyjs/helper-api-error": "1.5.13",
         "@webassemblyjs/helper-code-frame": "1.5.13",
         "@webassemblyjs/helper-fsm": "1.5.13",
-        "long": "3.2.0",
-        "mamacro": "0.0.3"
+        "long": "^3.2.0",
+        "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/wast-printer": {
@@ -317,7 +317,7 @@
       "requires": {
         "@webassemblyjs/ast": "1.5.13",
         "@webassemblyjs/wast-parser": "1.5.13",
-        "long": "3.2.0"
+        "long": "^3.2.0"
       }
     },
     "abab": {
@@ -338,7 +338,7 @@
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "^5.0.0"
       }
     },
     "acorn-globals": {
@@ -347,7 +347,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "^5.0.0"
       }
     },
     "acorn-jsx": {
@@ -356,7 +356,7 @@
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "^5.0.3"
       }
     },
     "ajv": {
@@ -365,10 +365,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -383,9 +383,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "kind-of": {
@@ -394,7 +394,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -435,8 +435,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "append-transform": {
@@ -445,7 +445,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "2.0.0"
+        "default-require-extensions": "^2.0.0"
       }
     },
     "aproba": {
@@ -460,7 +460,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "argv": {
@@ -499,7 +499,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -532,9 +532,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -587,7 +587,7 @@
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "lodash": {
@@ -640,9 +640,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -651,25 +651,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       }
     },
     "babel-generator": {
@@ -678,14 +678,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -694,9 +694,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -705,10 +705,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -717,10 +717,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -729,9 +729,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -740,11 +740,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -753,8 +753,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -763,8 +763,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -773,8 +773,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -783,9 +783,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -794,11 +794,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -807,12 +807,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -821,8 +821,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-jest": {
@@ -831,8 +831,8 @@
       "integrity": "sha1-FKnWo/QSLf6mBp03CFrfJqU6Tbo=",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "23.2.0"
+        "babel-plugin-istanbul": "^4.1.6",
+        "babel-preset-jest": "^23.2.0"
       }
     },
     "babel-loader": {
@@ -841,9 +841,9 @@
       "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "1.0.0",
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1"
+        "find-cache-dir": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "mkdirp": "^0.5.1"
       }
     },
     "babel-messages": {
@@ -852,7 +852,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-add-module-exports": {
@@ -867,7 +867,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -876,10 +876,10 @@
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "test-exclude": "4.2.1"
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "test-exclude": "^4.2.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -918,9 +918,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -929,7 +929,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -938,7 +938,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -947,11 +947,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -960,15 +960,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -977,8 +977,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -987,7 +987,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -996,8 +996,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1006,7 +1006,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1015,9 +1015,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1026,7 +1026,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1035,9 +1035,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1046,10 +1046,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1058,9 +1058,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1069,9 +1069,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1080,8 +1080,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1090,12 +1090,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1104,8 +1104,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1114,7 +1114,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1123,9 +1123,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1134,7 +1134,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1143,7 +1143,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1152,9 +1152,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1163,9 +1163,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1174,7 +1174,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -1183,7 +1183,7 @@
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1192,8 +1192,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -1202,9 +1202,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1221,36 +1221,36 @@
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "3.2.8",
-        "invariant": "2.2.4",
-        "semver": "5.5.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-jest": {
@@ -1259,8 +1259,8 @@
       "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "23.2.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
+        "babel-plugin-jest-hoist": "^23.2.0",
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
       }
     },
     "babel-register": {
@@ -1269,13 +1269,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -1283,8 +1283,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1293,11 +1293,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1306,15 +1306,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.5"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -1323,10 +1323,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -1347,13 +1347,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1362,7 +1362,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1371,7 +1371,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1380,7 +1380,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1389,9 +1389,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -1409,7 +1409,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "big.js": {
@@ -1442,7 +1442,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1452,16 +1452,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1470,7 +1470,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1510,12 +1510,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -1524,9 +1524,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.1",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -1535,9 +1535,9 @@
       "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -1546,8 +1546,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -1556,13 +1556,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -1571,7 +1571,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -1580,8 +1580,8 @@
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000865",
-        "electron-to-chromium": "1.3.51"
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
       }
     },
     "bser": {
@@ -1590,7 +1590,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "buffer": {
@@ -1599,9 +1599,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.12",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -1634,19 +1634,19 @@
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.2",
-        "mississippi": "2.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.3.0",
-        "unique-filename": "1.1.0",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.2.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
       },
       "dependencies": {
         "y18n": {
@@ -1663,15 +1663,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "caller-path": {
@@ -1680,7 +1680,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -1708,7 +1708,7 @@
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
       "dev": true,
       "requires": {
-        "rsvp": "3.6.2"
+        "rsvp": "^3.3.3"
       }
     },
     "caseless": {
@@ -1723,7 +1723,7 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "0.3.0"
+        "underscore-contrib": "~0.3.0"
       }
     },
     "center-align": {
@@ -1733,8 +1733,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -1743,11 +1743,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chardet": {
@@ -1762,19 +1762,19 @@
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.1",
-        "braces": "2.3.2",
-        "fsevents": "1.2.4",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.0",
-        "lodash.debounce": "4.0.8",
-        "normalize-path": "2.1.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0",
-        "upath": "1.1.0"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
       },
       "dependencies": {
         "glob-parent": {
@@ -1783,8 +1783,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -1793,7 +1793,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -1810,7 +1810,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         }
       }
@@ -1827,7 +1827,7 @@
       "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "^1.9.0"
       }
     },
     "ci-info": {
@@ -1842,8 +1842,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -1858,10 +1858,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1870,7 +1870,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -1881,7 +1881,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -1897,8 +1897,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -1935,10 +1935,10 @@
       "integrity": "sha512-KJyzHdg9B8U9LxXa7hS6jnEW5b1cNckLYc2YpnJ1nEFiOW+/iSzDHp+5MYEIQd9fN3/tC6WmGZmYiwxzkuGp/A==",
       "dev": true,
       "requires": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.1",
-        "request": "2.87.0",
-        "urlgrey": "0.4.4"
+        "argv": "^0.0.2",
+        "ignore-walk": "^3.0.1",
+        "request": "^2.87.0",
+        "urlgrey": "^0.4.4"
       }
     },
     "collection-visit": {
@@ -1947,8 +1947,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -1957,7 +1957,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -1972,7 +1972,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2011,10 +2011,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-browserify": {
@@ -2023,7 +2023,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -2050,12 +2050,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "copy-descriptor": {
@@ -2081,8 +2081,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -2091,11 +2091,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2104,12 +2104,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -2118,11 +2118,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.4",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-browserify": {
@@ -2131,17 +2131,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.16",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "cssom": {
@@ -2156,7 +2156,7 @@
       "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "dev": true,
       "requires": {
-        "cssom": "0.3.4"
+        "cssom": "0.3.x"
       }
     },
     "cyclist": {
@@ -2171,7 +2171,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -2180,9 +2180,9 @@
       "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.5.0"
+        "abab": "^1.0.4",
+        "whatwg-mimetype": "^2.0.0",
+        "whatwg-url": "^6.4.0"
       }
     },
     "date-fns": {
@@ -2191,9 +2191,9 @@
       "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
     },
     "date-format": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.0.tgz",
-      "integrity": "sha1-CSBoY6sHDrRZrOpVQsvYVrEZZrM=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
+      "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
       "dev": true
     },
     "date-now": {
@@ -2235,7 +2235,7 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "3.0.0"
+        "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -2252,8 +2252,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.12"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -2262,8 +2262,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2272,7 +2272,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2281,7 +2281,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2290,9 +2290,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -2303,13 +2303,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "pify": {
@@ -2332,8 +2332,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "detect-indent": {
@@ -2342,7 +2342,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-newline": {
@@ -2363,9 +2363,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "doctrine": {
@@ -2374,7 +2374,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-serializer": {
@@ -2383,8 +2383,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -2413,7 +2413,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "4.0.2"
+        "webidl-conversions": "^4.0.2"
       }
     },
     "domhandler": {
@@ -2422,7 +2422,7 @@
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -2431,8 +2431,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "duplexify": {
@@ -2441,10 +2441,10 @@
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -2454,7 +2454,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "electron-to-chromium": {
@@ -2469,13 +2469,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.5",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emojis-list": {
@@ -2490,7 +2490,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.21"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -2499,7 +2499,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -2508,9 +2508,9 @@
       "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "tapable": "1.0.0"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "tapable": "^1.0.0"
       }
     },
     "entities": {
@@ -2525,7 +2525,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -2534,7 +2534,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -2543,11 +2543,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -2556,9 +2556,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -2573,11 +2573,11 @@
       "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -2601,45 +2601,45 @@
       "integrity": "sha512-DyH6JsoA1KzA5+OSWFjg56DFJT+sDLO0yokaPZ9qY0UEmYrPA1gEX/G1MnVkmRDsksG4H1foIVz2ZXXM3hHYvw==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "4.0.0",
-        "eslint-utils": "1.3.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "4.0.0",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.7.0",
-        "ignore": "3.3.10",
-        "imurmurhash": "0.1.4",
-        "inquirer": "5.2.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "string.prototype.matchall": "2.0.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.3",
-        "text-table": "0.2.0"
+        "ajv": "^6.5.0",
+        "babel-code-frame": "^6.26.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^5.2.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.11.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.1.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.0",
+        "string.prototype.matchall": "^2.0.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^4.0.3",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ajv": {
@@ -2648,10 +2648,10 @@
           "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
           }
         },
         "ansi-regex": {
@@ -2666,7 +2666,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -2675,9 +2675,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "debug": {
@@ -2695,8 +2695,8 @@
           "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
           "dev": true,
           "requires": {
-            "esrecurse": "4.2.1",
-            "estraverse": "4.2.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         },
         "fast-deep-equal": {
@@ -2723,7 +2723,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -2732,7 +2732,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2743,9 +2743,9 @@
       "integrity": "sha512-hUFXRlE6AY84z0qYh4wKdtSF4EqDnyT8sxrvTpcXCV4ENSLF8li5yNA1yDM26iinH8Ierbpc4lv8Rp62uX6VSQ==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "0.1.1",
-        "object.assign": "4.1.0",
-        "object.entries": "1.0.4"
+        "eslint-restricted-globals": "^0.1.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
       }
     },
     "eslint-import-resolver-node": {
@@ -2754,8 +2754,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.8.1"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       }
     },
     "eslint-module-utils": {
@@ -2764,8 +2764,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -2774,8 +2774,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -2784,7 +2784,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -2793,7 +2793,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         }
       }
@@ -2804,16 +2804,16 @@
       "integrity": "sha512-t6hGKQDMIt9N8R7vLepsYXgDfeuhp6ZJSgtrLEDxonpSubyxUZHjhm6LsAaZX8q6GYVxkbT3kTsV9G5mBCFR6A==",
       "dev": true,
       "requires": {
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.2.0",
-        "has": "1.0.3",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0",
-        "resolve": "1.8.1"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
       },
       "dependencies": {
         "doctrine": {
@@ -2822,8 +2822,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -2832,10 +2832,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "path-type": {
@@ -2844,7 +2844,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "pify": {
@@ -2859,9 +2859,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -2870,8 +2870,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -2900,8 +2900,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -2922,8 +2922,8 @@
       "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1",
-        "acorn-jsx": "4.1.1"
+        "acorn": "^5.6.0",
+        "acorn-jsx": "^4.1.1"
       },
       "dependencies": {
         "acorn": {
@@ -2946,7 +2946,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -2955,7 +2955,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -2982,8 +2982,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exec-sh": {
@@ -2992,7 +2992,7 @@
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.2.0"
       }
     },
     "execa": {
@@ -3001,13 +3001,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -3016,9 +3016,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.2",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         }
       }
@@ -3035,13 +3035,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3050,7 +3050,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -3059,7 +3059,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3070,12 +3070,12 @@
       "integrity": "sha1-7LBRrcvcQKxNtXbBYGfxL9sTzGE=",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "jest-diff": "23.2.0",
-        "jest-get-type": "22.4.3",
-        "jest-matcher-utils": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-regex-util": "23.3.0"
+        "ansi-styles": "^3.2.0",
+        "jest-diff": "^23.2.0",
+        "jest-get-type": "^22.1.0",
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-regex-util": "^23.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3084,7 +3084,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         }
       }
@@ -3101,8 +3101,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3111,7 +3111,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -3122,9 +3122,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -3133,14 +3133,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3149,7 +3149,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -3158,7 +3158,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -3167,7 +3167,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3176,7 +3176,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3185,9 +3185,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3222,7 +3222,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "fetch-mock": {
@@ -3231,9 +3231,9 @@
       "integrity": "sha512-vwvgI6OTwVZHJ1sSQRnkf7oR69NI/UCukNY7XXKxcaMeKVcAt0DtvGS8tZk/uNHP4sKLiSDUN8KGJcvWHDB+5w==",
       "dev": true,
       "requires": {
-        "babel-polyfill": "6.26.0",
-        "glob-to-regexp": "0.4.0",
-        "path-to-regexp": "2.2.1"
+        "babel-polyfill": "^6.26.0",
+        "glob-to-regexp": "^0.4.0",
+        "path-to-regexp": "^2.2.1"
       }
     },
     "figures": {
@@ -3242,7 +3242,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -3251,8 +3251,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-url": {
@@ -3267,8 +3267,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "fill-range": {
@@ -3277,10 +3277,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3289,7 +3289,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3300,9 +3300,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.3.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-up": {
@@ -3311,7 +3311,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -3320,10 +3320,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flush-write-stream": {
@@ -3332,8 +3332,8 @@
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "for-in": {
@@ -3360,9 +3360,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -3371,7 +3371,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "from2": {
@@ -3380,8 +3380,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -3390,10 +3390,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -3409,8 +3409,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -3436,8 +3436,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -3450,7 +3450,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3514,7 +3514,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -3529,14 +3529,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -3545,12 +3545,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -3565,7 +3565,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -3574,7 +3574,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -3583,8 +3583,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3603,7 +3603,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -3617,7 +3617,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -3630,8 +3630,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -3640,7 +3640,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -3663,9 +3663,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -3674,16 +3674,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -3692,8 +3692,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -3708,8 +3708,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -3718,10 +3718,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -3740,7 +3740,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -3761,8 +3761,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -3783,10 +3783,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3803,13 +3803,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -3818,7 +3818,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -3861,9 +3861,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -3872,7 +3872,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -3880,7 +3880,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -3895,13 +3895,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -3916,7 +3916,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -3949,6 +3949,12 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -3967,7 +3973,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -3976,12 +3982,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-to-regexp": {
@@ -4008,12 +4014,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -4042,10 +4048,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -4060,7 +4066,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -4077,8 +4083,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -4087,7 +4093,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -4096,7 +4102,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -4117,9 +4123,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -4128,8 +4134,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4138,7 +4144,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4149,8 +4155,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -4159,8 +4165,8 @@
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "hmac-drbg": {
@@ -4169,9 +4175,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.5",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "home-or-tmp": {
@@ -4180,8 +4186,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -4196,7 +4202,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.3"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "htmlparser2": {
@@ -4205,12 +4211,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.7.0",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-signature": {
@@ -4219,9 +4225,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -4236,7 +4242,7 @@
       "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "^2.1.0"
       }
     },
     "ieee754": {
@@ -4263,7 +4269,7 @@
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.4"
       }
     },
     "import-local": {
@@ -4272,8 +4278,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -4294,8 +4300,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -4310,8 +4316,8 @@
       "integrity": "sha512-STx5orGQU1gfrkoI/fMU7lX6CSP7LBGO10gXNgOZhwKhUqbtNjCkYSewJtNnLmWP1tAGN6oyEpG1HFPw5vpa5Q==",
       "dev": true,
       "requires": {
-        "moment": "2.22.0",
-        "sanitize-html": "1.18.2"
+        "moment": "^2.14.1",
+        "sanitize-html": "^1.13.0"
       }
     },
     "inquirer": {
@@ -4320,19 +4326,19 @@
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.5",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.1.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "5.5.11",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^5.5.2",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4347,7 +4353,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4356,9 +4362,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "strip-ansi": {
@@ -4367,7 +4373,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -4376,7 +4382,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4393,7 +4399,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -4408,7 +4414,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4417,7 +4423,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4434,7 +4440,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -4449,7 +4455,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -4464,7 +4470,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.3"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -4473,7 +4479,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4482,7 +4488,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4499,9 +4505,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4524,7 +4530,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4545,7 +4551,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4554,7 +4560,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4565,7 +4571,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -4588,7 +4594,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -4597,7 +4603,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-object": {
@@ -4606,7 +4612,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -4621,7 +4627,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -4684,8 +4690,8 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.4"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -4700,18 +4706,18 @@
       "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "compare-versions": "3.3.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.2.1",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.4",
-        "istanbul-lib-source-maps": "1.2.5",
-        "istanbul-reports": "1.3.0",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
+        "async": "^2.1.4",
+        "compare-versions": "^3.1.0",
+        "fileset": "^2.0.2",
+        "istanbul-lib-coverage": "^1.2.0",
+        "istanbul-lib-hook": "^1.2.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "istanbul-lib-report": "^1.1.4",
+        "istanbul-lib-source-maps": "^1.2.4",
+        "istanbul-reports": "^1.3.0",
+        "js-yaml": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0"
       }
     },
     "istanbul-lib-coverage": {
@@ -4726,7 +4732,7 @@
       "integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
       "dev": true,
       "requires": {
-        "append-transform": "1.0.0"
+        "append-transform": "^1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -4735,13 +4741,13 @@
       "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.1",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "semver": "5.5.0"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.2.0",
+        "semver": "^5.3.0"
       }
     },
     "istanbul-lib-report": {
@@ -4750,10 +4756,10 @@
       "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
+        "istanbul-lib-coverage": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "path-parse": "^1.0.5",
+        "supports-color": "^3.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -4768,7 +4774,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -4779,11 +4785,11 @@
       "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
+        "debug": "^3.1.0",
+        "istanbul-lib-coverage": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.1",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "debug": {
@@ -4803,7 +4809,7 @@
       "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.11"
+        "handlebars": "^4.0.3"
       }
     },
     "jest": {
@@ -4812,8 +4818,8 @@
       "integrity": "sha1-E1XNeS84zyD7pNoC3dt8oU2UhLU=",
       "dev": true,
       "requires": {
-        "import-local": "1.0.0",
-        "jest-cli": "23.3.0"
+        "import-local": "^1.0.0",
+        "jest-cli": "^23.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4828,7 +4834,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4837,9 +4843,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "jest-cli": {
@@ -4848,42 +4854,42 @@
           "integrity": "sha1-MH6b53M0Q7eJqCedaUBU0FGp5eI=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "exit": "0.1.2",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "import-local": "1.0.0",
-            "is-ci": "1.1.0",
-            "istanbul-api": "1.3.1",
-            "istanbul-lib-coverage": "1.2.0",
-            "istanbul-lib-instrument": "1.10.1",
-            "istanbul-lib-source-maps": "1.2.5",
-            "jest-changed-files": "23.2.0",
-            "jest-config": "23.3.0",
-            "jest-environment-jsdom": "23.3.0",
-            "jest-get-type": "22.4.3",
-            "jest-haste-map": "23.2.0",
-            "jest-message-util": "23.3.0",
-            "jest-regex-util": "23.3.0",
-            "jest-resolve-dependencies": "23.3.0",
-            "jest-runner": "23.3.0",
-            "jest-runtime": "23.3.0",
-            "jest-snapshot": "23.3.0",
-            "jest-util": "23.3.0",
-            "jest-validate": "23.3.0",
-            "jest-watcher": "23.2.0",
-            "jest-worker": "23.2.0",
-            "micromatch": "3.1.10",
-            "node-notifier": "5.2.1",
-            "prompts": "0.1.11",
-            "realpath-native": "1.0.1",
-            "rimraf": "2.6.2",
-            "slash": "1.0.0",
-            "string-length": "2.0.0",
-            "strip-ansi": "4.0.0",
-            "which": "1.3.1",
-            "yargs": "11.1.0"
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "import-local": "^1.0.0",
+            "is-ci": "^1.0.10",
+            "istanbul-api": "^1.3.1",
+            "istanbul-lib-coverage": "^1.2.0",
+            "istanbul-lib-instrument": "^1.10.1",
+            "istanbul-lib-source-maps": "^1.2.4",
+            "jest-changed-files": "^23.2.0",
+            "jest-config": "^23.3.0",
+            "jest-environment-jsdom": "^23.3.0",
+            "jest-get-type": "^22.1.0",
+            "jest-haste-map": "^23.2.0",
+            "jest-message-util": "^23.3.0",
+            "jest-regex-util": "^23.3.0",
+            "jest-resolve-dependencies": "^23.3.0",
+            "jest-runner": "^23.3.0",
+            "jest-runtime": "^23.3.0",
+            "jest-snapshot": "^23.3.0",
+            "jest-util": "^23.3.0",
+            "jest-validate": "^23.3.0",
+            "jest-watcher": "^23.2.0",
+            "jest-worker": "^23.2.0",
+            "micromatch": "^3.1.10",
+            "node-notifier": "^5.2.1",
+            "prompts": "^0.1.9",
+            "realpath-native": "^1.0.0",
+            "rimraf": "^2.5.4",
+            "slash": "^1.0.0",
+            "string-length": "^2.0.0",
+            "strip-ansi": "^4.0.0",
+            "which": "^1.2.12",
+            "yargs": "^11.0.0"
           }
         },
         "strip-ansi": {
@@ -4892,7 +4898,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -4901,7 +4907,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4912,7 +4918,7 @@
       "integrity": "sha1-oUWm5LZtASn8fJnO4TTck3pkPZw=",
       "dev": true,
       "requires": {
-        "throat": "4.1.0"
+        "throat": "^4.0.0"
       }
     },
     "jest-config": {
@@ -4921,19 +4927,19 @@
       "integrity": "sha1-u01Ttw+VAPr933GNImq7U7E7gyM=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-jest": "23.2.0",
-        "chalk": "2.4.1",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "23.3.0",
-        "jest-environment-node": "23.3.0",
-        "jest-get-type": "22.4.3",
-        "jest-jasmine2": "23.3.0",
-        "jest-regex-util": "23.3.0",
-        "jest-resolve": "23.2.0",
-        "jest-util": "23.3.0",
-        "jest-validate": "23.3.0",
-        "pretty-format": "23.2.0"
+        "babel-core": "^6.0.0",
+        "babel-jest": "^23.2.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^23.3.0",
+        "jest-environment-node": "^23.3.0",
+        "jest-get-type": "^22.1.0",
+        "jest-jasmine2": "^23.3.0",
+        "jest-regex-util": "^23.3.0",
+        "jest-resolve": "^23.2.0",
+        "jest-util": "^23.3.0",
+        "jest-validate": "^23.3.0",
+        "pretty-format": "^23.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4942,7 +4948,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4951,9 +4957,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -4962,7 +4968,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4973,10 +4979,10 @@
       "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "diff": "3.5.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^23.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4985,7 +4991,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4994,9 +5000,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5005,7 +5011,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5016,7 +5022,7 @@
       "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
       "dev": true,
       "requires": {
-        "detect-newline": "2.1.0"
+        "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
@@ -5025,8 +5031,8 @@
       "integrity": "sha1-pAD4HIVwg/UMT1M5mxCfEgI/sZ0=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "pretty-format": "^23.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5035,7 +5041,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5044,9 +5050,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5055,7 +5061,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5066,9 +5072,9 @@
       "integrity": "sha1-GQRX+RyeYVRUxBhgVgZdtu16Tio=",
       "dev": true,
       "requires": {
-        "jest-mock": "23.2.0",
-        "jest-util": "23.3.0",
-        "jsdom": "11.11.0"
+        "jest-mock": "^23.2.0",
+        "jest-util": "^23.3.0",
+        "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
@@ -5077,8 +5083,8 @@
       "integrity": "sha1-Ho3yHIR6pdA7dlc/DcFvzeUDTDI=",
       "dev": true,
       "requires": {
-        "jest-mock": "23.2.0",
-        "jest-util": "23.3.0"
+        "jest-mock": "^23.2.0",
+        "jest-util": "^23.3.0"
       }
     },
     "jest-fetch-mock": {
@@ -5087,9 +5093,9 @@
       "integrity": "sha512-qPz5Zf8+W16pu6cvdwXkb2SwRfxGoQbbGB6HcIBFND0gnWKMfQilZew3PSODnOWQZF/pzBPi7ZIT6Yz5D0va1Q==",
       "dev": true,
       "requires": {
-        "@types/jest": "23.1.5",
-        "isomorphic-fetch": "2.2.1",
-        "promise-polyfill": "7.1.2"
+        "@types/jest": "^23.0.0",
+        "isomorphic-fetch": "^2.2.1",
+        "promise-polyfill": "^7.1.1"
       }
     },
     "jest-get-type": {
@@ -5104,13 +5110,13 @@
       "integrity": "sha1-0Qy6wAfGlZSMjvGCGisu0tTy1Ng=",
       "dev": true,
       "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "23.2.0",
-        "jest-serializer": "23.0.1",
-        "jest-worker": "23.2.0",
-        "micromatch": "3.1.10",
-        "sane": "2.5.2"
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-docblock": "^23.2.0",
+        "jest-serializer": "^23.0.1",
+        "jest-worker": "^23.2.0",
+        "micromatch": "^3.1.10",
+        "sane": "^2.0.0"
       }
     },
     "jest-jasmine2": {
@@ -5119,17 +5125,17 @@
       "integrity": "sha1-qHBrqsI8ihMNWqjvVGSp1JCW0bU=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "co": "4.6.0",
-        "expect": "23.3.0",
-        "is-generator-fn": "1.0.0",
-        "jest-diff": "23.2.0",
-        "jest-each": "23.2.0",
-        "jest-matcher-utils": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-snapshot": "23.3.0",
-        "jest-util": "23.3.0",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^23.3.0",
+        "is-generator-fn": "^1.0.0",
+        "jest-diff": "^23.2.0",
+        "jest-each": "^23.2.0",
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-snapshot": "^23.3.0",
+        "jest-util": "^23.3.0",
+        "pretty-format": "^23.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5138,7 +5144,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5147,9 +5153,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5158,7 +5164,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5169,7 +5175,7 @@
       "integrity": "sha1-wonZYdxjjxQ1fU75bgQx7MGqN30=",
       "dev": true,
       "requires": {
-        "pretty-format": "23.2.0"
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-matcher-utils": {
@@ -5178,9 +5184,9 @@
       "integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^23.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5189,7 +5195,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5198,9 +5204,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5209,7 +5215,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5220,11 +5226,11 @@
       "integrity": "sha1-vAexHOxpcftd2d4t+2DrwiFQwWA=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.52",
-        "chalk": "2.4.1",
-        "micromatch": "3.1.10",
-        "slash": "1.0.0",
-        "stack-utils": "1.0.1"
+        "@babel/code-frame": "^7.0.0-beta.35",
+        "chalk": "^2.0.1",
+        "micromatch": "^3.1.10",
+        "slash": "^1.0.0",
+        "stack-utils": "^1.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5233,7 +5239,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5242,9 +5248,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5253,7 +5259,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5276,9 +5282,9 @@
       "integrity": "sha1-oHkK1aO5kAKrTb/L+Nni1qabPZk=",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.3",
-        "chalk": "2.4.1",
-        "realpath-native": "1.0.1"
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "realpath-native": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5287,7 +5293,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5296,9 +5302,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5307,7 +5313,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5318,8 +5324,8 @@
       "integrity": "sha1-hETTsLEoi4CGTYgB/1C0Sk1pXR0=",
       "dev": true,
       "requires": {
-        "jest-regex-util": "23.3.0",
-        "jest-snapshot": "23.3.0"
+        "jest-regex-util": "^23.3.0",
+        "jest-snapshot": "^23.3.0"
       }
     },
     "jest-runner": {
@@ -5328,19 +5334,19 @@
       "integrity": "sha1-BMfkWKYXUBpIddsNf/vg48vUO/s=",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.3.0",
-        "jest-docblock": "23.2.0",
-        "jest-haste-map": "23.2.0",
-        "jest-jasmine2": "23.3.0",
-        "jest-leak-detector": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-runtime": "23.3.0",
-        "jest-util": "23.3.0",
-        "jest-worker": "23.2.0",
-        "source-map-support": "0.5.6",
-        "throat": "4.1.0"
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^23.3.0",
+        "jest-docblock": "^23.2.0",
+        "jest-haste-map": "^23.2.0",
+        "jest-jasmine2": "^23.3.0",
+        "jest-leak-detector": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-runtime": "^23.3.0",
+        "jest-util": "^23.3.0",
+        "jest-worker": "^23.2.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -5355,8 +5361,8 @@
           "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.0.0",
-            "source-map": "0.6.1"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           }
         }
       }
@@ -5367,27 +5373,27 @@
       "integrity": "sha1-SGWqtM7/gvnOxjNf164UIswd598=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-plugin-istanbul": "4.1.6",
-        "chalk": "2.4.1",
-        "convert-source-map": "1.5.1",
-        "exit": "0.1.2",
-        "fast-json-stable-stringify": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.3.0",
-        "jest-haste-map": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-regex-util": "23.3.0",
-        "jest-resolve": "23.2.0",
-        "jest-snapshot": "23.3.0",
-        "jest-util": "23.3.0",
-        "jest-validate": "23.3.0",
-        "micromatch": "3.1.10",
-        "realpath-native": "1.0.1",
-        "slash": "1.0.0",
+        "babel-core": "^6.0.0",
+        "babel-plugin-istanbul": "^4.1.6",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "exit": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^23.3.0",
+        "jest-haste-map": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-regex-util": "^23.3.0",
+        "jest-resolve": "^23.2.0",
+        "jest-snapshot": "^23.3.0",
+        "jest-util": "^23.3.0",
+        "jest-validate": "^23.3.0",
+        "micromatch": "^3.1.10",
+        "realpath-native": "^1.0.0",
+        "slash": "^1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "11.1.0"
+        "write-file-atomic": "^2.1.0",
+        "yargs": "^11.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5396,7 +5402,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5405,9 +5411,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "strip-bom": {
@@ -5422,7 +5428,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5439,17 +5445,17 @@
       "integrity": "sha1-/E6fgeRUMtEFB+J/ULzmD0TYFCQ=",
       "dev": true,
       "requires": {
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "chalk": "2.4.1",
-        "jest-diff": "23.2.0",
-        "jest-matcher-utils": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-resolve": "23.2.0",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "23.2.0",
-        "semver": "5.5.0"
+        "babel-traverse": "^6.0.0",
+        "babel-types": "^6.0.0",
+        "chalk": "^2.0.1",
+        "jest-diff": "^23.2.0",
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-resolve": "^23.2.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^23.2.0",
+        "semver": "^5.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5458,7 +5464,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5467,9 +5473,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5478,7 +5484,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5489,14 +5495,14 @@
       "integrity": "sha1-efNbsMMBAO9hHZY+5riPjthzqB0=",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0",
-        "chalk": "2.4.1",
-        "graceful-fs": "4.1.11",
-        "is-ci": "1.1.0",
-        "jest-message-util": "23.3.0",
-        "mkdirp": "0.5.1",
-        "slash": "1.0.0",
-        "source-map": "0.6.1"
+        "callsites": "^2.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.11",
+        "is-ci": "^1.0.10",
+        "jest-message-util": "^23.3.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5505,7 +5511,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "callsites": {
@@ -5520,9 +5526,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "source-map": {
@@ -5537,7 +5543,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5548,10 +5554,10 @@
       "integrity": "sha1-1Jvqaq2YwwrNLLtUJDR5igzBP3Y=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "jest-get-type": "22.4.3",
-        "leven": "2.1.0",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^23.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5560,7 +5566,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5569,9 +5575,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5580,7 +5586,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5591,9 +5597,9 @@
       "integrity": "sha1-Z46FKJbpGenZoOtLi68a4nliDqk=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "string-length": "2.0.0"
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "string-length": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5602,7 +5608,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5611,9 +5617,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -5622,7 +5628,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5633,7 +5639,7 @@
       "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
       "dev": true,
       "requires": {
-        "merge-stream": "1.0.1"
+        "merge-stream": "^1.0.1"
       }
     },
     "js-tokens": {
@@ -5648,8 +5654,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "js2xmlparser": {
@@ -5658,7 +5664,7 @@
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
       "dev": true,
       "requires": {
-        "xmlcreate": "1.0.2"
+        "xmlcreate": "^1.0.1"
       }
     },
     "jsbn": {
@@ -5675,17 +5681,17 @@
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.1",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "js2xmlparser": "3.0.0",
-        "klaw": "2.0.0",
-        "marked": "0.3.19",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
+        "bluebird": "~3.5.0",
+        "catharsis": "~0.8.9",
+        "escape-string-regexp": "~1.0.5",
+        "js2xmlparser": "~3.0.0",
+        "klaw": "~2.0.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "1.8.3"
+        "underscore": "~1.8.3"
       },
       "dependencies": {
         "babylon": {
@@ -5702,32 +5708,32 @@
       "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.5.3",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "cssom": "0.3.4",
-        "cssstyle": "0.3.1",
-        "data-urls": "1.0.0",
-        "domexception": "1.0.1",
-        "escodegen": "1.10.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.3.0",
-        "nwsapi": "2.0.4",
+        "abab": "^1.0.4",
+        "acorn": "^5.3.0",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.3.1 < 0.4.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.0",
+        "escodegen": "^1.9.0",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.2.0",
+        "nwsapi": "^2.0.0",
         "parse5": "4.0.0",
-        "pn": "1.1.0",
-        "request": "2.87.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.4",
-        "w3c-hr-time": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.5.0",
-        "ws": "4.1.0",
-        "xml-name-validator": "3.0.0"
+        "pn": "^1.1.0",
+        "request": "^2.83.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.3",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^4.0.0",
+        "xml-name-validator": "^3.0.0"
       }
     },
     "jsesc": {
@@ -5796,7 +5802,7 @@
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazy-cache": {
@@ -5812,7 +5818,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "left-pad": {
@@ -5833,8 +5839,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -5843,11 +5849,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5870,9 +5876,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -5881,8 +5887,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -5939,14 +5945,32 @@
       "dev": true
     },
     "log4js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-1.1.1.tgz",
-      "integrity": "sha1-wh0px2BAieTyVYM+f5SzRh3h/0M=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.4.tgz",
+      "integrity": "sha512-4rQ1TrOf85lxB0+hBiPF27Zw8pGTHxKZq8FYfum1TNhx/KMUlQ+LL4bMKcdzc7zoAFF992w8+MFQm3BQbUgePA==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "semver": "5.5.0",
-        "streamroller": "0.4.1"
+        "circular-json": "^0.5.5",
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "streamroller": "0.7.0"
+      },
+      "dependencies": {
+        "circular-json": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.5.tgz",
+          "integrity": "sha512-13YaR6kiz0kBNmIVM87Io8Hp7bWOo4r61vkEANy8iH9R9bc6avud/1FT0SBpqR1RpIQADOh/Q+yHZDA1iL6ysA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "long": {
@@ -5967,7 +5991,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -5976,8 +6000,8 @@
       "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -5986,7 +6010,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "makeerror": {
@@ -5995,7 +6019,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "mamacro": {
@@ -6016,7 +6040,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "marked": {
@@ -6031,8 +6055,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "mem": {
@@ -6041,7 +6065,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memory-fs": {
@@ -6050,8 +6074,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.6"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "merge": {
@@ -6066,7 +6090,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       }
     },
     "micromatch": {
@@ -6075,19 +6099,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.9",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "miller-rabin": {
@@ -6096,8 +6120,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime-db": {
@@ -6112,7 +6136,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -6139,7 +6163,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -6154,16 +6178,16 @@
       "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexify": "3.6.0",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.0.3",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "2.0.1",
-        "pumpify": "1.5.1",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^2.0.1",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -6172,8 +6196,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6182,7 +6206,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -6208,12 +6232,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -6234,9 +6258,9 @@
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "nan": {
@@ -6252,18 +6276,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "natural-compare": {
@@ -6290,8 +6314,8 @@
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-int64": {
@@ -6306,28 +6330,28 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.6",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.1.1",
-        "timers-browserify": "2.0.10",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.4",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       }
     },
@@ -6337,10 +6361,10 @@
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.5.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.1"
+        "growly": "^1.3.0",
+        "semver": "^5.4.1",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "normalize-package-data": {
@@ -6349,10 +6373,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -6361,7 +6385,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -6370,7 +6394,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -6403,9 +6427,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -6414,7 +6438,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -6423,7 +6447,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6440,7 +6464,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.assign": {
@@ -6449,10 +6473,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.0.12"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.entries": {
@@ -6461,10 +6485,10 @@
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -6473,8 +6497,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.pick": {
@@ -6483,7 +6507,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "once": {
@@ -6492,7 +6516,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -6501,7 +6525,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -6510,8 +6534,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -6528,12 +6552,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-browserify": {
@@ -6554,9 +6578,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -6577,7 +6601,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -6586,7 +6610,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -6607,9 +6631,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "parse-asn1": {
@@ -6618,11 +6642,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.16"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-json": {
@@ -6631,7 +6655,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse5": {
@@ -6700,9 +6724,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -6719,11 +6743,11 @@
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -6750,7 +6774,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -6759,7 +6783,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "pluralize": {
@@ -6786,9 +6810,9 @@
       "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.2",
-        "source-map": "0.6.1",
-        "supports-color": "5.3.0"
+        "chalk": "^2.3.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6797,7 +6821,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -6806,9 +6830,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "source-map": {
@@ -6823,7 +6847,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -6846,8 +6870,8 @@
       "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.1"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6862,7 +6886,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         }
       }
@@ -6909,8 +6933,8 @@
       "integrity": "sha512-6ZFzPasWMEgZ/cDpQQshV/l/fWISILGjq4VctCipG6RVfaO4FAafGR8iKXSFxoHIYgPcPYuDupyLtVNc/aDG8Q==",
       "dev": true,
       "requires": {
-        "clorox": "1.0.3",
-        "sisteransi": "0.1.1"
+        "clorox": "^1.0.3",
+        "sisteransi": "^0.1.1"
       }
     },
     "prr": {
@@ -6931,11 +6955,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pump": {
@@ -6944,8 +6968,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -6954,9 +6978,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "3.6.0",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -6988,7 +7012,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -6997,8 +7021,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "read-pkg": {
@@ -7007,9 +7031,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -7018,8 +7042,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -7028,8 +7052,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -7038,7 +7062,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -7049,13 +7073,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -7064,10 +7088,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "realpath-native": {
@@ -7076,7 +7100,7 @@
       "integrity": "sha512-W14EcXuqUvKP8dkWkD7B95iMy77lpMnlFXbbk409bQtNCbeu0kvRE5reo+yIZ3JXxg6frbGsz2DLQ39lrCB40g==",
       "dev": true,
       "requires": {
-        "util.promisify": "1.0.0"
+        "util.promisify": "^1.0.0"
       }
     },
     "regenerate": {
@@ -7096,9 +7120,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-not": {
@@ -7107,8 +7131,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexp.prototype.flags": {
@@ -7117,7 +7141,7 @@
       "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2"
+        "define-properties": "^1.1.2"
       }
     },
     "regexpp": {
@@ -7132,9 +7156,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -7149,7 +7173,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -7184,7 +7208,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -7193,26 +7217,26 @@
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.1",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-promise-core": {
@@ -7221,7 +7245,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.13.1"
       }
     },
     "request-promise-native": {
@@ -7231,8 +7255,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.4"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "require-directory": {
@@ -7253,8 +7277,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "requizzle": {
@@ -7263,7 +7287,7 @@
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
-        "underscore": "1.6.0"
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "underscore": {
@@ -7280,7 +7304,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-cwd": {
@@ -7289,7 +7313,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -7318,8 +7342,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -7335,7 +7359,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -7344,7 +7368,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -7353,8 +7377,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rsvp": {
@@ -7369,7 +7393,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-queue": {
@@ -7378,7 +7402,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "rxjs": {
@@ -7402,7 +7426,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -7417,15 +7441,15 @@
       "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "capture-exit": "1.2.0",
-        "exec-sh": "0.2.2",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.2.4",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
+        "anymatch": "^2.0.0",
+        "capture-exit": "^1.2.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.3",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
       },
       "dependencies": {
         "minimist": {
@@ -7442,16 +7466,16 @@
       "integrity": "sha512-52ThA+Z7h6BnvpSVbURwChl10XZrps5q7ytjTwWcIe9bmJwnVP6cpEVK2NvDOUhGupoqAvNbUz3cpnJDp4+/pg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.2",
-        "htmlparser2": "3.9.2",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.escaperegexp": "4.1.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mergewith": "4.6.1",
-        "postcss": "6.0.21",
-        "srcset": "1.0.0",
-        "xtend": "4.0.1"
+        "chalk": "^2.3.0",
+        "htmlparser2": "^3.9.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mergewith": "^4.6.0",
+        "postcss": "^6.0.14",
+        "srcset": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7460,7 +7484,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -7469,9 +7493,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -7480,7 +7504,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -7497,8 +7521,8 @@
       "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.2",
-        "ajv-keywords": "3.2.0"
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0"
       },
       "dependencies": {
         "ajv": {
@@ -7507,10 +7531,10 @@
           "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
           }
         },
         "ajv-keywords": {
@@ -7563,10 +7587,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7575,7 +7599,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7592,8 +7616,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -7602,7 +7626,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -7641,7 +7665,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "snapdragon": {
@@ -7650,14 +7674,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7666,7 +7690,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -7675,7 +7699,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7686,9 +7710,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -7697,7 +7721,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -7706,7 +7730,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -7715,7 +7739,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -7724,9 +7748,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -7737,7 +7761,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7746,7 +7770,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -7769,11 +7793,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "2.1.0",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.0.0",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -7782,7 +7806,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -7797,8 +7821,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -7813,8 +7837,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7829,7 +7853,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -7844,8 +7868,8 @@
       "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3",
-        "number-is-nan": "1.0.1"
+        "array-uniq": "^1.0.2",
+        "number-is-nan": "^1.0.0"
       }
     },
     "sshpk": {
@@ -7854,15 +7878,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -7871,7 +7895,7 @@
       "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "stack-utils": {
@@ -7886,8 +7910,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7896,7 +7920,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -7913,8 +7937,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-each": {
@@ -7923,8 +7947,8 @@
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -7933,11 +7957,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -7947,46 +7971,25 @@
       "dev": true
     },
     "streamroller": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.4.1.tgz",
-      "integrity": "sha1-1DW9WXQ3Or2b2QaDWVEwhRBswF8=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
+      "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
-        "date-format": "0.0.0",
-        "debug": "0.7.4",
-        "mkdirp": "0.5.1",
-        "readable-stream": "1.1.14"
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "readable-stream": "^2.3.0"
       },
       "dependencies": {
         "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "ms": "2.0.0"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         }
       }
     },
@@ -7996,8 +7999,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8012,7 +8015,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -8023,8 +8026,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8039,7 +8042,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -8050,11 +8053,11 @@
       "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "regexp.prototype.flags": "1.2.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "string_decoder": {
@@ -8063,7 +8066,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -8072,7 +8075,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -8081,7 +8084,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-eof": {
@@ -8097,31 +8100,32 @@
       "dev": true
     },
     "stryker": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/stryker/-/stryker-0.24.2.tgz",
-      "integrity": "sha512-s6qtJkBjrWBETMUOTzH+YhlToIUyeBr6+b5cHn2hO1Ds1hjqFn4C8i4rlMvRvdoTYPHeDQ6t07udua5d95kOBg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/stryker/-/stryker-0.25.1.tgz",
+      "integrity": "sha512-2HbKrBzSeHqCLG2+vzZ58dpMbfCTsZc1cu1IU787wLt3pm/2FZnWa2OSkqWMCxMZfHCJ8ETKAZm4anMbpFPqZA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "commander": "2.16.0",
-        "escodegen": "1.10.0",
-        "esprima": "2.7.3",
-        "glob": "7.1.2",
-        "inquirer": "6.0.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "lodash": "4.17.5",
-        "log4js": "1.1.1",
-        "mkdirp": "0.5.1",
-        "mz": "2.7.0",
-        "prettier": "1.13.7",
-        "progress": "2.0.0",
-        "rimraf": "2.6.2",
-        "rxjs": "6.2.1",
-        "source-map": "0.6.1",
-        "surrial": "0.1.3",
-        "tree-kill": "1.2.0",
-        "tslib": "1.9.0",
-        "typed-rest-client": "1.0.7"
+        "chalk": "~2.4.1",
+        "commander": "~2.16.0",
+        "escodegen": "~1.8.0",
+        "esprima": "~2.7.0",
+        "get-port": "~3.2.0",
+        "glob": "~7.1.2",
+        "inquirer": "~6.0.0",
+        "istanbul-lib-instrument": "~1.10.1",
+        "lodash": "~4.17.4",
+        "log4js": "~3.0.0",
+        "mkdirp": "~0.5.1",
+        "mz": "~2.7.0",
+        "prettier": "~1.13.7",
+        "progress": "~2.0.0",
+        "rimraf": "~2.6.1",
+        "rxjs": "~6.2.2",
+        "source-map": "~0.6.1",
+        "surrial": "~0.1.3",
+        "tree-kill": "~1.2.0",
+        "tslib": "~1.9.3",
+        "typed-rest-client": "~1.0.7"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8136,7 +8140,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -8145,9 +8149,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "chardet": {
@@ -8156,21 +8160,52 @@
           "integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g==",
           "dev": true
         },
+        "escodegen": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+          "dev": true,
+          "requires": {
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         },
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        },
         "external-editor": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.0.tgz",
-          "integrity": "sha512-mpkfj0FEdxrIhOC04zk85X7StNtr0yXnG7zCb+8ikO8OJi2jsHh5YGoknNTyXgsbHOf1WOOcVU3kPFWT2WgCkQ==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.1.tgz",
+          "integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
           "dev": true,
           "requires": {
-            "chardet": "0.5.0",
-            "iconv-lite": "0.4.23",
-            "tmp": "0.0.33"
+            "chardet": "^0.5.0",
+            "iconv-lite": "^0.4.22",
+            "tmp": "^0.0.33"
           }
         },
         "iconv-lite": {
@@ -8179,7 +8214,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "inquirer": {
@@ -8188,28 +8223,28 @@
           "integrity": "sha512-tISQWRwtcAgrz+SHPhTH7d3e73k31gsOy6i1csonLc0u1dVK/wYvuOnFeiWqC5OXFIYbmrIFInef31wbT8MEJg==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "3.0.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.5",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "6.2.1",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rxjs": "^6.1.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "rxjs": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
-          "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
+          "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
           "dev": true,
           "requires": {
-            "tslib": "1.9.0"
+            "tslib": "^1.9.0"
           }
         },
         "source-map": {
@@ -8224,7 +8259,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -8233,68 +8268,94 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+          "dev": true
         }
       }
     },
     "stryker-api": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/stryker-api/-/stryker-api-0.17.3.tgz",
-      "integrity": "sha512-/6NAlZ/olwStF4B26aIFOtafyEa8ImjQdua8O7GL9tFl6AjdijJLsD72emJp/fLKhc1sQD3tX6SYclhrhilbuA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/stryker-api/-/stryker-api-0.18.0.tgz",
+      "integrity": "sha512-i7GS/RP1OqJrHisjtFaDQSj72GyIH3GZXUrlhQEzufd/df9JwI4binRpRk/9zmeobOpa6yqd8OTbyfMaYd5TBg==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "~1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+          "dev": true
+        }
       }
     },
     "stryker-babel-transpiler": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/stryker-babel-transpiler/-/stryker-babel-transpiler-0.5.3.tgz",
-      "integrity": "sha512-PJwALXWLJDZK60/WZwnydj+OjCYbzDTY02tHWec25LGNS1Gl/W6qVEGHzG8EXmJB7zOYm7RxYNmc9qUAmxb9CQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/stryker-babel-transpiler/-/stryker-babel-transpiler-0.6.1.tgz",
+      "integrity": "sha512-g6R8SpPouHByLEsOB6HSZwuU2hi9TfNREU6mW+MBE3wE3xlDugJ38G6Fv0d3VZCoa4JFy3a2TM0KG8629kqHBw==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.3",
-        "log4js": "1.1.1",
-        "minimatch": "3.0.4"
+        "minimatch": "~3.0.4"
       }
     },
     "stryker-html-reporter": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/stryker-html-reporter/-/stryker-html-reporter-0.14.3.tgz",
-      "integrity": "sha512-vxARSA0RYeC4Kr1hf/YAPwd3DfKLFsoUKafLChqZYl2SQm7nvjCu2fy1jSdH6NEJArH1eWOTFo8Inl3M7P74Gw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/stryker-html-reporter/-/stryker-html-reporter-0.15.1.tgz",
+      "integrity": "sha512-bX4qKGWKm/zVwKa0Im4/ZQqSHljMe17dLeSx5GJ8duY8ESpWFiR4Ggr5QvXeRqSyiKi0i+GaX2+TwIrUHakbfA==",
       "dev": true,
       "requires": {
-        "file-url": "2.0.2",
-        "lodash": "4.17.5",
-        "log4js": "1.1.1",
-        "mkdirp": "0.5.1",
-        "mz": "2.7.0",
-        "rimraf": "2.6.2",
-        "typed-html": "0.6.0"
+        "file-url": "~2.0.0",
+        "lodash": "~4.17.10",
+        "mkdirp": "~0.5.1",
+        "mz": "~2.7.0",
+        "rimraf": "~2.6.1",
+        "typed-html": "~0.6.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
       }
     },
     "stryker-javascript-mutator": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/stryker-javascript-mutator/-/stryker-javascript-mutator-0.7.3.tgz",
-      "integrity": "sha512-h07D+SRmNjc3JHKb8WJln2ijMFuuBY++vf0JGp7qC5J5loDrNpPDbSMPtEzmMwZa5iLNTrF1lAMwgStgzvMnvw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/stryker-javascript-mutator/-/stryker-javascript-mutator-0.8.0.tgz",
+      "integrity": "sha512-Fr4lCMdogZsfHXSxz89Wih16bZRwRL8drVwf/fUK4IILf51fz2Wz2Va0QT18h7hmjhNsE51UTcPg0Phkz2aakg==",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-generator": "6.26.1",
-        "babylon": "6.18.0",
-        "lodash": "4.17.5",
-        "log4js": "1.1.1",
-        "tslib": "1.9.0"
+        "babel-core": "~6.26.0",
+        "babel-generator": "~6.26.0",
+        "babylon": "~6.18.0",
+        "lodash": "~4.17.4",
+        "tslib": "~1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+          "dev": true
+        }
       }
     },
     "stryker-jest-runner": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/stryker-jest-runner/-/stryker-jest-runner-0.7.0.tgz",
-      "integrity": "sha512-/VcE0baqNegNPlpYJMBWVukdu7sDm+cgXcrGAvVScJcxEec3EG3EDTENJxsuYvVk0SF4SBTJobDsTQBdKttsLw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stryker-jest-runner/-/stryker-jest-runner-1.0.1.tgz",
+      "integrity": "sha512-o5KnWK6p77FZ1pY/u3cPvk2YDKx404Bf0AoRpQy+IG8ipdJgHj754g2jzUmK8/Br05U/Lli1g5ZaVrY73L+UEA==",
       "dev": true,
       "requires": {
-        "log4js": "1.1.1",
-        "semver": "5.5.0"
+        "semver": "~5.5.0"
       }
     },
     "supports-color": {
@@ -8327,12 +8388,12 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.2",
-        "ajv-keywords": "3.2.0",
-        "chalk": "2.4.1",
-        "lodash": "4.17.5",
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ajv": {
@@ -8341,10 +8402,10 @@
           "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
           }
         },
         "ansi-styles": {
@@ -8353,7 +8414,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -8362,9 +8423,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "fast-deep-equal": {
@@ -8385,7 +8446,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -8408,11 +8469,11 @@
       "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "3.1.10",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^3.1.8",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       }
     },
     "text-table": {
@@ -8427,7 +8488,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -8436,7 +8497,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "throat": {
@@ -8457,8 +8518,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "timers-browserify": {
@@ -8467,7 +8528,7 @@
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "tmp": {
@@ -8476,7 +8537,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -8503,7 +8564,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8512,7 +8573,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8523,10 +8584,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -8535,8 +8596,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -8545,7 +8606,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tr46": {
@@ -8554,7 +8615,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -8601,7 +8662,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -8617,7 +8678,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typed-html": {
@@ -8649,9 +8710,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "yargs": {
@@ -8661,9 +8722,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -8682,14 +8743,14 @@
       "integrity": "sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==",
       "dev": true,
       "requires": {
-        "cacache": "10.0.4",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.4.5",
-        "serialize-javascript": "1.5.0",
-        "source-map": "0.6.1",
-        "uglify-es": "3.3.9",
-        "webpack-sources": "1.1.0",
-        "worker-farm": "1.6.0"
+        "cacache": "^10.0.4",
+        "find-cache-dir": "^1.0.0",
+        "schema-utils": "^0.4.5",
+        "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
+        "uglify-es": "^3.3.4",
+        "webpack-sources": "^1.1.0",
+        "worker-farm": "^1.5.2"
       },
       "dependencies": {
         "commander": {
@@ -8710,8 +8771,8 @@
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -8745,10 +8806,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -8757,7 +8818,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -8766,10 +8827,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -8780,7 +8841,7 @@
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "dev": true,
       "requires": {
-        "unique-slug": "2.0.0"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -8789,7 +8850,7 @@
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "unset-value": {
@@ -8798,8 +8859,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -8808,9 +8869,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -8844,7 +8905,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -8891,7 +8952,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       }
     },
     "util": {
@@ -8915,8 +8976,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "uuid": {
@@ -8937,8 +8998,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -8947,9 +9008,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -8967,7 +9028,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "0.1.2"
+        "browser-process-hrtime": "^0.1.2"
       }
     },
     "walker": {
@@ -8976,7 +9037,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "watch": {
@@ -8985,8 +9046,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "0.2.2",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -9003,9 +9064,9 @@
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.4",
-        "graceful-fs": "4.1.11",
-        "neo-async": "2.5.1"
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
       }
     },
     "webidl-conversions": {
@@ -9025,26 +9086,26 @@
         "@webassemblyjs/wasm-edit": "1.5.13",
         "@webassemblyjs/wasm-opt": "1.5.13",
         "@webassemblyjs/wasm-parser": "1.5.13",
-        "acorn": "5.7.1",
-        "acorn-dynamic-import": "3.0.0",
-        "ajv": "6.5.2",
-        "ajv-keywords": "3.2.0",
-        "chrome-trace-event": "1.0.0",
-        "enhanced-resolve": "4.1.0",
-        "eslint-scope": "3.7.1",
-        "json-parse-better-errors": "1.0.2",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.1",
-        "neo-async": "2.5.1",
-        "node-libs-browser": "2.1.0",
-        "schema-utils": "0.4.5",
-        "tapable": "1.0.0",
-        "uglifyjs-webpack-plugin": "1.2.7",
-        "watchpack": "1.6.0",
-        "webpack-sources": "1.1.0"
+        "acorn": "^5.6.2",
+        "acorn-dynamic-import": "^3.0.0",
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "chrome-trace-event": "^1.0.0",
+        "enhanced-resolve": "^4.1.0",
+        "eslint-scope": "^3.7.1",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "micromatch": "^3.1.8",
+        "mkdirp": "~0.5.0",
+        "neo-async": "^2.5.0",
+        "node-libs-browser": "^2.0.0",
+        "schema-utils": "^0.4.4",
+        "tapable": "^1.0.0",
+        "uglifyjs-webpack-plugin": "^1.2.4",
+        "watchpack": "^1.5.0",
+        "webpack-sources": "^1.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -9059,10 +9120,10 @@
           "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
           }
         },
         "ajv-keywords": {
@@ -9091,17 +9152,17 @@
       "integrity": "sha512-KnRLJ0BUaYRqrhAMb9dv3gzdmhmgIMKo0FmdsnmfqbPGtLnnZ6tORZAvmmKfr+A0VgiVpqC60Gv7Ofg0R2CHtQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "enhanced-resolve": "4.1.0",
-        "global-modules-path": "2.1.0",
-        "import-local": "1.0.0",
-        "inquirer": "6.0.0",
-        "interpret": "1.1.0",
-        "loader-utils": "1.1.0",
-        "supports-color": "5.4.0",
-        "v8-compile-cache": "2.0.0",
-        "yargs": "11.1.0"
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "enhanced-resolve": "^4.0.0",
+        "global-modules-path": "^2.1.0",
+        "import-local": "^1.0.0",
+        "inquirer": "^6.0.0",
+        "interpret": "^1.1.0",
+        "loader-utils": "^1.1.0",
+        "supports-color": "^5.4.0",
+        "v8-compile-cache": "^2.0.0",
+        "yargs": "^11.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9116,7 +9177,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -9125,9 +9186,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "chardet": {
@@ -9142,9 +9203,9 @@
           "integrity": "sha512-mpkfj0FEdxrIhOC04zk85X7StNtr0yXnG7zCb+8ikO8OJi2jsHh5YGoknNTyXgsbHOf1WOOcVU3kPFWT2WgCkQ==",
           "dev": true,
           "requires": {
-            "chardet": "0.5.0",
-            "iconv-lite": "0.4.23",
-            "tmp": "0.0.33"
+            "chardet": "^0.5.0",
+            "iconv-lite": "^0.4.22",
+            "tmp": "^0.0.33"
           }
         },
         "iconv-lite": {
@@ -9153,7 +9214,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "inquirer": {
@@ -9162,19 +9223,19 @@
           "integrity": "sha512-tISQWRwtcAgrz+SHPhTH7d3e73k31gsOy6i1csonLc0u1dVK/wYvuOnFeiWqC5OXFIYbmrIFInef31wbT8MEJg==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "3.0.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.5",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "6.2.1",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rxjs": "^6.1.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "rxjs": {
@@ -9183,7 +9244,7 @@
           "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
           "dev": true,
           "requires": {
-            "tslib": "1.9.0"
+            "tslib": "^1.9.0"
           }
         },
         "strip-ansi": {
@@ -9192,7 +9253,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -9201,7 +9262,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -9212,8 +9273,8 @@
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -9259,9 +9320,9 @@
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {
@@ -9270,7 +9331,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -9298,7 +9359,7 @@
       "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.7"
       }
     },
     "wrap-ansi": {
@@ -9307,8 +9368,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -9317,7 +9378,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -9326,9 +9387,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -9345,7 +9406,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -9354,9 +9415,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -9365,8 +9426,8 @@
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0"
       }
     },
     "xml-name-validator": {
@@ -9405,18 +9466,18 @@
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {
-        "cliui": "4.1.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^9.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9431,9 +9492,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -9442,7 +9503,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -9453,7 +9514,7 @@
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Sequoia client SDK for Javascript",
   "main": "dist/web/sequoia-client.js",
   "scripts": {

--- a/test/fixtures/image-asset.json
+++ b/test/fixtures/image-asset.json
@@ -10,8 +10,8 @@
  "updatedAt": "2016-09-30T08:00:26.662Z",
  "updatedBy": "demo:demo-admin",
  "version": "7a1e1092fd4a2a24c39dc733ccbc36599b169b95",
- "mediaType": "image",
- "fullMediaType": "application/octet-stream",
+ "type": "image",
+ "fullType": "application/octet-stream",
  "url": "https://s3-eu-west-1.amazonaws.com/demo.datasets.sequoia.piksel.com/images/viacom/BlackInk0516HD-00DDDE0000111630681304.jpg",
  "contentRef": "demo:XPTL0000000000444282"
 }

--- a/test/fixtures/image-asset.json
+++ b/test/fixtures/image-asset.json
@@ -11,7 +11,7 @@
  "updatedBy": "demo:demo-admin",
  "version": "7a1e1092fd4a2a24c39dc733ccbc36599b169b95",
  "type": "image",
- "fullType": "application/octet-stream",
+ "fullMediaType": "application/octet-stream",
  "url": "https://s3-eu-west-1.amazonaws.com/demo.datasets.sequoia.piksel.com/images/viacom/BlackInk0516HD-00DDDE0000111630681304.jpg",
  "contentRef": "demo:XPTL0000000000444282"
 }

--- a/test/fixtures/media-items-1.json
+++ b/test/fixtures/media-items-1.json
@@ -12,25 +12,25 @@
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061"
         },
         {
           "totalCount": 60,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033"
         }
       ]
     }
@@ -308,7 +308,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15035-LI.jpg",
         "fileFormat": "jpg",
         "title": "Brave",
@@ -321,7 +321,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0650/UTV-15035-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Brave",
@@ -335,7 +335,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15035-PI.jpg",
         "fileFormat": "jpg",
         "title": "Brave",
@@ -348,7 +348,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0648/UTV-15034-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Battleship",
@@ -361,7 +361,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0940/UTV-15131-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Bolt",
@@ -375,7 +375,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15131-PI.jpg",
         "fileFormat": "jpg",
         "title": "Bolt",
@@ -388,7 +388,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15131-LI.jpg",
         "fileFormat": "jpg",
         "title": "Bolt",
@@ -401,7 +401,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15065-LI.jpg",
         "fileFormat": "jpg",
         "title": "Battle: Los Angeles",
@@ -415,7 +415,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15034-PI.jpg",
         "fileFormat": "jpg",
         "title": "Battleship",
@@ -428,7 +428,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836992003025/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Bolt",
@@ -441,7 +441,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566971287429/pikselss.ism",
         "fileFormat": "ism",
         "title": "Bolt",
@@ -454,7 +454,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869851017493/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Bolt",
@@ -467,7 +467,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828566459997/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Battleship",
@@ -480,7 +480,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558654354725/pikselss.ism",
         "fileFormat": "ism",
         "title": "Brave",
@@ -493,7 +493,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861168508474/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Brave",
@@ -506,7 +506,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863662829747/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Battle: Los Angeles",
@@ -519,7 +519,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15034-LI.jpg",
         "fileFormat": "jpg",
         "title": "Battleship",
@@ -532,7 +532,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0718/UTV-15065-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Battle: Los Angeles",
@@ -546,7 +546,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15065-PI.jpg",
         "fileFormat": "jpg",
         "title": "Battle: Los Angeles",
@@ -559,7 +559,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828666135192/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Brave",
@@ -572,7 +572,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860928273398/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Battleship",
@@ -585,7 +585,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558263728740/pikselss.ism",
         "fileFormat": "ism",
         "title": "Battleship",
@@ -598,7 +598,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561723747780/pikselss.ism",
         "fileFormat": "ism",
         "title": "Battle: Los Angeles",
@@ -611,7 +611,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831225257649/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Battle: Los Angeles",
@@ -624,7 +624,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1022/UTV-15130-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Angels & Demons",
@@ -638,7 +638,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15164-PI.jpg",
         "fileFormat": "jpg",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -651,7 +651,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15164-LI.jpg",
         "fileFormat": "jpg",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -665,7 +665,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15061-PI.jpg",
         "fileFormat": "jpg",
         "title": "Battle Royale",
@@ -678,7 +678,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15061-LI.jpg",
         "fileFormat": "jpg",
         "title": "Battle Royale",
@@ -691,7 +691,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0828/UTV-BOX-15038-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Anchorman 2: The Legend Continues",
@@ -704,7 +704,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0903/UTV-15061-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Battle Royale",
@@ -718,7 +718,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15129-PI.jpg",
         "fileFormat": "jpg",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -731,7 +731,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0937/UTV-15129-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -744,7 +744,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15129-LI.jpg",
         "fileFormat": "jpg",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -757,7 +757,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0716/UTV-15064-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Arthur Christmas",
@@ -771,7 +771,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15199-PI.jpg",
         "fileFormat": "jpg",
         "title": "American Gangster",
@@ -784,7 +784,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15199-LI.jpg",
         "fileFormat": "jpg",
         "title": "American Gangster",
@@ -797,7 +797,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1356/UTV-15199-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "American Gangster",
@@ -810,7 +810,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0806/UTV-15096-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Alice In Wonderland",
@@ -823,7 +823,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15096-LI.jpg",
         "fileFormat": "jpg",
         "title": "Alice In Wonderland",
@@ -836,7 +836,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1544/UTV-15002-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "After Earth",
@@ -849,7 +849,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15002-LI.jpg",
         "fileFormat": "jpg",
         "title": "After Earth",
@@ -862,7 +862,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/9/7/landscape/UTV-15003-LI.jpg",
         "fileFormat": "jpg",
         "title": "Alan Partridge: Alpha Papa",
@@ -876,7 +876,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/9/7/portrait/UTV-15003-PI.jpg",
         "fileFormat": "jpg",
         "title": "Alan Partridge: Alpha Papa",
@@ -889,7 +889,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869773341327/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Angels & Demons",
@@ -902,7 +902,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/IBC/UTV-15061/pvptest.ism",
         "fileFormat": "ism",
         "title": "Battle Royale",
@@ -915,7 +915,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836810848278/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -928,7 +928,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566566793775/pikselss.ism",
         "fileFormat": "ism",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -941,7 +941,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836898817637/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Angels & Demons",
@@ -954,7 +954,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566640799455/pikselss.ism",
         "fileFormat": "ism",
         "title": "Angels & Demons",
@@ -967,7 +967,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873209844087/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -980,7 +980,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863571445477/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Arthur Christmas",
@@ -993,7 +993,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834275303248/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Alice In Wonderland",
@@ -1006,7 +1006,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570431293898/pikselss.ism",
         "fileFormat": "ism",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -1019,7 +1019,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561488070435/pikselss.ism",
         "fileFormat": "ism",
         "title": "Arthur Christmas",
@@ -1032,7 +1032,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106857844368431/piksel.mpd",
         "fileFormat": "mpd",
         "title": "After Earth",
@@ -1045,7 +1045,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825338935081/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Alan Partridge: Alpha Papa",
@@ -1058,7 +1058,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825198575222/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "After Earth",
@@ -1070,7 +1070,7 @@
         "tags": [
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "2015/09/07/0652/ssManifest.ism",
         "title": "Alan Partridge: Alpha Papa",
         "contentRef": "sa-team:UTV-15003"
@@ -1081,7 +1081,7 @@
         "tags": [
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "2015/09/07/0652/Manifest.m3u8",
         "title": "Alan Partridge: Alpha Papa",
         "contentRef": "sa-team:UTV-15003"
@@ -1093,7 +1093,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884132761407/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Anchorman 2: The Legend Continues",
@@ -1106,7 +1106,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582002228884/pikselss.ism",
         "fileFormat": "ism",
         "title": "Anchorman 2: The Legend Continues",
@@ -1119,7 +1119,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1050/UTV-15164-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -1132,7 +1132,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15130-LI.jpg",
         "fileFormat": "jpg",
         "title": "Angels & Demons",
@@ -1146,7 +1146,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15130-PI.jpg",
         "fileFormat": "jpg",
         "title": "Angels & Demons",
@@ -1160,7 +1160,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15038-PI.jpg",
         "fileFormat": "jpg",
         "title": "Anchorman 2: The Legend Continues",
@@ -1173,7 +1173,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15038-LI.jpg",
         "fileFormat": "jpg",
         "title": "Anchorman 2: The Legend Continues",
@@ -1186,7 +1186,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15064-LI.jpg",
         "fileFormat": "jpg",
         "title": "Arthur Christmas",
@@ -1200,7 +1200,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15064-PI.jpg",
         "fileFormat": "jpg",
         "title": "Arthur Christmas",
@@ -1214,7 +1214,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15096-PI.jpg",
         "fileFormat": "jpg",
         "title": "Alice In Wonderland",
@@ -1228,7 +1228,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15002-PI.jpg",
         "fileFormat": "jpg",
         "title": "After Earth",
@@ -1241,7 +1241,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869695478410/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -1254,7 +1254,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173564061987959/pikselss.ism",
         "fileFormat": "ism",
         "title": "Alice In Wonderland",
@@ -1267,7 +1267,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842959197652/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "American Gangster",
@@ -1280,7 +1280,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875816223403/piksel.mpd",
         "fileFormat": "mpd",
         "title": "American Gangster",
@@ -1293,7 +1293,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573518657745/pikselss.ism",
         "fileFormat": "ism",
         "title": "American Gangster",
@@ -1306,7 +1306,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839974130555/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -1319,7 +1319,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106866244599926/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Alice In Wonderland",
@@ -1332,7 +1332,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831135462024/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Arthur Christmas",
@@ -1345,7 +1345,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555706498614/pikselss.ism",
         "fileFormat": "ism",
         "title": "After Earth",
@@ -1358,7 +1358,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555074011806/pikselss.ism",
         "fileFormat": "ism",
         "title": "Alan Partridge: Alpha Papa",
@@ -1371,7 +1371,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106857918689335/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Alan Partridge: Alpha Papa",
@@ -1384,7 +1384,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851154874080/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Anchorman 2: The Legend Continues",
@@ -1397,7 +1397,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15011-LI.jpg",
         "fileFormat": "jpg",
         "title": "300: Rise of An Empire",
@@ -1410,7 +1410,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1436/UTV-BOX-15011-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "300: Rise of An Empire",
@@ -1423,7 +1423,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1053/UTV-15162-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "10,000 BC",
@@ -1436,7 +1436,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15019-LI.jpg",
         "fileFormat": "jpg",
         "title": "12 Years a Slave",
@@ -1450,7 +1450,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15000-PI.jpg",
         "fileFormat": "jpg",
         "title": "A Good Day To Die Hard",
@@ -1463,7 +1463,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1534/UTV-15000-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "A Good Day To Die Hard",
@@ -1476,7 +1476,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15000-LI.jpg",
         "fileFormat": "jpg",
         "title": "A Good Day To Die Hard",
@@ -1489,7 +1489,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1453/UTV-15033-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -1502,7 +1502,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15127-LI.jpg",
         "fileFormat": "jpg",
         "title": "2012",
@@ -1515,7 +1515,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1541/UTV-15001-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "About Time",
@@ -1528,7 +1528,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15001-LI.jpg",
         "fileFormat": "jpg",
         "title": "About Time",
@@ -1541,7 +1541,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1322/UTV-BOX-15006-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "22 Jump Street",
@@ -1555,7 +1555,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15006-PI.jpg",
         "fileFormat": "jpg",
         "title": "22 Jump Street",
@@ -1568,7 +1568,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15006-LI.jpg",
         "fileFormat": "jpg",
         "title": "22 Jump Street",
@@ -1582,7 +1582,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15019-PI.jpg",
         "fileFormat": "jpg",
         "title": "12 Years a Slave",
@@ -1595,7 +1595,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1704/UTV-BOX-15019-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "12 Years a Slave",
@@ -1609,7 +1609,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15033-PI.jpg",
         "fileFormat": "jpg",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -1623,7 +1623,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15127-PI.jpg",
         "fileFormat": "jpg",
         "title": "2012",
@@ -1636,7 +1636,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0930/UTV-15127-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "2012",
@@ -1649,7 +1649,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15033-LI.jpg",
         "fileFormat": "jpg",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -1663,7 +1663,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15163-PI.jpg",
         "fileFormat": "jpg",
         "title": "27 Dresses",
@@ -1676,7 +1676,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0932/UTV-15128-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "A Christmas Carol",
@@ -1689,7 +1689,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1049/UTV-15163-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "27 Dresses",
@@ -1702,7 +1702,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15163-LI.jpg",
         "fileFormat": "jpg",
         "title": "27 Dresses",
@@ -1715,7 +1715,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882010514535/piksel.mpd",
         "fileFormat": "mpd",
         "title": "300: Rise of An Empire",
@@ -1728,7 +1728,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848678882224/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "300: Rise of An Empire",
@@ -1741,7 +1741,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566245914468/pikselss.ism",
         "fileFormat": "ism",
         "title": "2012",
@@ -1754,7 +1754,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848135301978/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "22 Jump Street",
@@ -1767,7 +1767,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106857689704594/piksel.mpd",
         "fileFormat": "mpd",
         "title": "A Good Day To Die Hard",
@@ -1780,7 +1780,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558023923570/pikselss.ism",
         "fileFormat": "ism",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -1793,7 +1793,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555232851499/pikselss.ism",
         "fileFormat": "ism",
         "title": "A Good Day To Die Hard",
@@ -1806,7 +1806,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860841843054/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -1819,7 +1819,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873056840198/piksel.mpd",
         "fileFormat": "mpd",
         "title": "10,000 BC",
@@ -1832,7 +1832,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836603233682/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "A Christmas Carol",
@@ -1845,7 +1845,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566320966671/pikselss.ism",
         "fileFormat": "ism",
         "title": "A Christmas Carol",
@@ -1858,7 +1858,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106857770254149/piksel.mpd",
         "fileFormat": "mpd",
         "title": "About Time",
@@ -1871,7 +1871,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839792292284/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "10,000 BC",
@@ -1884,7 +1884,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570172621416/pikselss.ism",
         "fileFormat": "ism",
         "title": "10,000 BC",
@@ -1897,7 +1897,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579170712705/pikselss.ism",
         "fileFormat": "ism",
         "title": "22 Jump Street",
@@ -1910,7 +1910,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839881931961/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "27 Dresses",
@@ -1923,7 +1923,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873133578707/piksel.mpd",
         "fileFormat": "mpd",
         "title": "27 Dresses",
@@ -1936,7 +1936,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570259391805/pikselss.ism",
         "fileFormat": "ism",
         "title": "27 Dresses",
@@ -1949,7 +1949,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849496369339/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "12 Years a Slave",
@@ -1962,7 +1962,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580455640168/pikselss.ism",
         "fileFormat": "ism",
         "title": "12 Years a Slave",
@@ -1976,7 +1976,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15011-PI.jpg",
         "fileFormat": "jpg",
         "title": "300: Rise of An Empire",
@@ -1989,7 +1989,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15162-LI.jpg",
         "fileFormat": "jpg",
         "title": "10,000 BC",
@@ -2003,7 +2003,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15162-PI.jpg",
         "fileFormat": "jpg",
         "title": "10,000 BC",
@@ -2017,7 +2017,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15001-PI.jpg",
         "fileFormat": "jpg",
         "title": "About Time",
@@ -2030,7 +2030,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15128-LI.jpg",
         "fileFormat": "jpg",
         "title": "A Christmas Carol",
@@ -2044,7 +2044,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15128-PI.jpg",
         "fileFormat": "jpg",
         "title": "A Christmas Carol",
@@ -2057,7 +2057,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836525779196/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "2012",
@@ -2070,7 +2070,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869386805104/piksel.mpd",
         "fileFormat": "mpd",
         "title": "2012",
@@ -2083,7 +2083,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579008642425/pikselss.ism",
         "fileFormat": "ism",
         "title": "300: Rise of An Empire",
@@ -2096,7 +2096,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881419417325/piksel.mpd",
         "fileFormat": "mpd",
         "title": "22 Jump Street",
@@ -2109,7 +2109,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869608616890/piksel.mpd",
         "fileFormat": "mpd",
         "title": "A Christmas Carol",
@@ -2122,7 +2122,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121824911979830/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "A Good Day To Die Hard",
@@ -2135,7 +2135,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825026944282/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "About Time",
@@ -2148,7 +2148,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828445685712/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -2161,7 +2161,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555469473992/pikselss.ism",
         "fileFormat": "ism",
         "title": "About Time",
@@ -2174,7 +2174,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882619527754/piksel.mpd",
         "fileFormat": "mpd",
         "title": "12 Years a Slave",

--- a/test/fixtures/media-items-10.json
+++ b/test/fixtures/media-items-10.json
@@ -13,25 +13,25 @@
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15050%7C%7Csa-team%3AUTV-BOX-15001%7C%7Csa-team%3AUTV-15193%7C%7Csa-team%3AUTV-15121&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15050%7C%7Csa-team%3AUTV-BOX-15001%7C%7Csa-team%3AUTV-15193%7C%7Csa-team%3AUTV-15121&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15050%7C%7Csa-team%3AUTV-BOX-15001%7C%7Csa-team%3AUTV-15193%7C%7Csa-team%3AUTV-15121"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15050%7C%7Csa-team%3AUTV-BOX-15001%7C%7Csa-team%3AUTV-15193%7C%7Csa-team%3AUTV-15121&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15050%7C%7Csa-team%3AUTV-BOX-15001%7C%7Csa-team%3AUTV-15193%7C%7Csa-team%3AUTV-15121&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15050%7C%7Csa-team%3AUTV-BOX-15001%7C%7Csa-team%3AUTV-15193%7C%7Csa-team%3AUTV-15121"
         },
         {
           "totalCount": 60,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15054%7C%7Csa-team%3AUTV-15249%7C%7Csa-team%3AUTV-15055%7C%7Csa-team%3AUTV-15119%7C%7Csa-team%3AUTV-BOX-15016%7C%7Csa-team%3AUTV-15250%7C%7Csa-team%3AUTV-15221%7C%7Csa-team%3AUTV-BOX-15020%7C%7Csa-team%3AUTV-15154%7C%7Csa-team%3AUTV-15088&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15054%7C%7Csa-team%3AUTV-15249%7C%7Csa-team%3AUTV-15055%7C%7Csa-team%3AUTV-15119%7C%7Csa-team%3AUTV-BOX-15016%7C%7Csa-team%3AUTV-15250%7C%7Csa-team%3AUTV-15221%7C%7Csa-team%3AUTV-BOX-15020%7C%7Csa-team%3AUTV-15154%7C%7Csa-team%3AUTV-15088&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15054%7C%7Csa-team%3AUTV-15249%7C%7Csa-team%3AUTV-15055%7C%7Csa-team%3AUTV-15119%7C%7Csa-team%3AUTV-BOX-15016%7C%7Csa-team%3AUTV-15250%7C%7Csa-team%3AUTV-15221%7C%7Csa-team%3AUTV-BOX-15020%7C%7Csa-team%3AUTV-15154%7C%7Csa-team%3AUTV-15088"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15054%7C%7Csa-team%3AUTV-15249%7C%7Csa-team%3AUTV-15055%7C%7Csa-team%3AUTV-15119%7C%7Csa-team%3AUTV-BOX-15016%7C%7Csa-team%3AUTV-15250%7C%7Csa-team%3AUTV-15221%7C%7Csa-team%3AUTV-BOX-15020%7C%7Csa-team%3AUTV-15154%7C%7Csa-team%3AUTV-15088&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15054%7C%7Csa-team%3AUTV-15249%7C%7Csa-team%3AUTV-15055%7C%7Csa-team%3AUTV-15119%7C%7Csa-team%3AUTV-BOX-15016%7C%7Csa-team%3AUTV-15250%7C%7Csa-team%3AUTV-15221%7C%7Csa-team%3AUTV-BOX-15020%7C%7Csa-team%3AUTV-15154%7C%7Csa-team%3AUTV-15088&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15054%7C%7Csa-team%3AUTV-15249%7C%7Csa-team%3AUTV-15055%7C%7Csa-team%3AUTV-15119%7C%7Csa-team%3AUTV-BOX-15016%7C%7Csa-team%3AUTV-15250%7C%7Csa-team%3AUTV-15221%7C%7Csa-team%3AUTV-BOX-15020%7C%7Csa-team%3AUTV-15154%7C%7Csa-team%3AUTV-15088"
         },
         {
           "totalCount": 60,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15025%7C%7Csa-team%3AUTV-15222%7C%7Csa-team%3AUTV-15056%7C%7Csa-team%3AUTV-15026%7C%7Csa-team%3AUTV-15191%7C%7Csa-team%3AUTV-15057%7C%7Csa-team%3AUTV-15027%7C%7Csa-team%3AUTV-15089%7C%7Csa-team%3AUTV-15192%7C%7Csa-team%3AUTV-15120&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15025%7C%7Csa-team%3AUTV-15222%7C%7Csa-team%3AUTV-15056%7C%7Csa-team%3AUTV-15026%7C%7Csa-team%3AUTV-15191%7C%7Csa-team%3AUTV-15057%7C%7Csa-team%3AUTV-15027%7C%7Csa-team%3AUTV-15089%7C%7Csa-team%3AUTV-15192%7C%7Csa-team%3AUTV-15120&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15025%7C%7Csa-team%3AUTV-15222%7C%7Csa-team%3AUTV-15056%7C%7Csa-team%3AUTV-15026%7C%7Csa-team%3AUTV-15191%7C%7Csa-team%3AUTV-15057%7C%7Csa-team%3AUTV-15027%7C%7Csa-team%3AUTV-15089%7C%7Csa-team%3AUTV-15192%7C%7Csa-team%3AUTV-15120"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15025%7C%7Csa-team%3AUTV-15222%7C%7Csa-team%3AUTV-15056%7C%7Csa-team%3AUTV-15026%7C%7Csa-team%3AUTV-15191%7C%7Csa-team%3AUTV-15057%7C%7Csa-team%3AUTV-15027%7C%7Csa-team%3AUTV-15089%7C%7Csa-team%3AUTV-15192%7C%7Csa-team%3AUTV-15120&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15025%7C%7Csa-team%3AUTV-15222%7C%7Csa-team%3AUTV-15056%7C%7Csa-team%3AUTV-15026%7C%7Csa-team%3AUTV-15191%7C%7Csa-team%3AUTV-15057%7C%7Csa-team%3AUTV-15027%7C%7Csa-team%3AUTV-15089%7C%7Csa-team%3AUTV-15192%7C%7Csa-team%3AUTV-15120&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15025%7C%7Csa-team%3AUTV-15222%7C%7Csa-team%3AUTV-15056%7C%7Csa-team%3AUTV-15026%7C%7Csa-team%3AUTV-15191%7C%7Csa-team%3AUTV-15057%7C%7Csa-team%3AUTV-15027%7C%7Csa-team%3AUTV-15089%7C%7Csa-team%3AUTV-15192%7C%7Csa-team%3AUTV-15120"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0837/UTV-BOX-15001-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Lego Movie",
@@ -324,7 +324,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15001-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Lego Movie",
@@ -337,7 +337,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1346/UTV-15193-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Mummy: Tomb Of The Dragon Emperor",
@@ -350,7 +350,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15121-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Other Guys",
@@ -363,7 +363,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0858/UTV-15121-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Other Guys",
@@ -377,7 +377,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15001-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Lego Movie",
@@ -390,7 +390,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0850/UTV-BOX-15050-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Last Exorcism Part II",
@@ -403,7 +403,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15050-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Last Exorcism Part II",
@@ -417,7 +417,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15050-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Last Exorcism Part II",
@@ -430,7 +430,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106868841879192/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Other Guys",
@@ -443,7 +443,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578301290489/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Lego Movie",
@@ -456,7 +456,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880833518654/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Lego Movie",
@@ -469,7 +469,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847618580813/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Lego Movie",
@@ -482,7 +482,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106885143792166/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Last Exorcism Part II",
@@ -495,7 +495,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121852396441296/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Last Exorcism Part II",
@@ -508,7 +508,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15193-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Mummy: Tomb Of The Dragon Emperor",
@@ -522,7 +522,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15193-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Mummy: Tomb Of The Dragon Emperor",
@@ -536,7 +536,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15121-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Other Guys",
@@ -549,7 +549,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836002099563/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Other Guys",
@@ -562,7 +562,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566481717910/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Other Guys",
@@ -575,7 +575,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842485816838/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Mummy: Tomb Of The Dragon Emperor",
@@ -588,7 +588,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875392259669/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Mummy: Tomb Of The Dragon Emperor",
@@ -601,7 +601,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572224395803/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Mummy: Tomb Of The Dragon Emperor",
@@ -614,7 +614,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173583088416234/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Last Exorcism Part II",
@@ -627,7 +627,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15020-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Grand Budapest Hotel",
@@ -640,7 +640,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15055-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Dictator",
@@ -653,7 +653,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1339/UTV-BOX-15016-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Expendables 3",
@@ -667,7 +667,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15055-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Dictator",
@@ -680,7 +680,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1428/UTV-15221-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Golden Compass",
@@ -694,7 +694,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15221-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Golden Compass",
@@ -707,7 +707,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/1210/UTV-BOX-15020-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Grand Budapest Hotel",
@@ -720,7 +720,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0708/UTV-15054-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Devil Inside",
@@ -733,7 +733,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15054-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Devil Inside",
@@ -746,7 +746,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1501/UTV-15249-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Devil Wears Prada",
@@ -760,7 +760,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15119-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Expendables",
@@ -773,7 +773,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0753/UTV-15088-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Hangover Part II",
@@ -787,7 +787,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15088-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Hangover Part II",
@@ -801,7 +801,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15054-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Devil Inside",
@@ -815,7 +815,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15249-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Devil Wears Prada",
@@ -828,7 +828,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0853/UTV-15119-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Expendables",
@@ -841,7 +841,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15250-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Fast And The Furious: Tokyo Drift",
@@ -855,7 +855,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15250-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Fast And The Furious: Tokyo Drift",
@@ -868,7 +868,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15154-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Hangover",
@@ -882,7 +882,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15154-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Hangover",
@@ -895,7 +895,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1037/UTV-15154-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Hangover",
@@ -908,7 +908,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862933245691/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Dictator",
@@ -921,7 +921,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173560531825853/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Dictator",
@@ -934,7 +934,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849133414928/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Expendables 3",
@@ -947,7 +947,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882323654471/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Expendables 3",
@@ -960,7 +960,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579661116275/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Expendables 3",
@@ -973,7 +973,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878054119021/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Golden Compass",
@@ -986,7 +986,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576467136834/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Golden Compass",
@@ -999,7 +999,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106868676092368/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Expendables",
@@ -1012,7 +1012,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847420583147/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Fast And The Furious: Tokyo Drift",
@@ -1025,7 +1025,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880667026690/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Fast And The Furious: Tokyo Drift",
@@ -1038,7 +1038,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847336222829/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Devil Wears Prada",
@@ -1051,7 +1051,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880448753823/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Devil Wears Prada",
@@ -1064,7 +1064,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862859943173/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Devil Inside",
@@ -1077,7 +1077,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578459664530/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Devil Wears Prada",
@@ -1090,7 +1090,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569110479027/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Hangover",
@@ -1103,7 +1103,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173560442948295/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Devil Inside",
@@ -1116,7 +1116,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833704981815/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Hangover Part II",
@@ -1129,7 +1129,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872402533444/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Hangover",
@@ -1142,7 +1142,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849575752988/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Grand Budapest Hotel",
@@ -1155,7 +1155,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882695860640/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Grand Budapest Hotel",
@@ -1169,7 +1169,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15016-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Expendables 3",
@@ -1182,7 +1182,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15221-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Golden Compass",
@@ -1195,7 +1195,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0847/UTV-15055-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Dictator",
@@ -1209,7 +1209,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15020-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Grand Budapest Hotel",
@@ -1222,7 +1222,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15016-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Expendables 3",
@@ -1235,7 +1235,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15249-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Devil Wears Prada",
@@ -1248,7 +1248,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15119-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Expendables",
@@ -1261,7 +1261,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15088-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Hangover Part II",
@@ -1274,7 +1274,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1502/UTV-15250-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Fast And The Furious: Tokyo Drift",
@@ -1287,7 +1287,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844863537654/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Golden Compass",
@@ -1300,7 +1300,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830474051175/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Dictator",
@@ -1313,7 +1313,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830393197563/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Devil Inside",
@@ -1326,7 +1326,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566160408705/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Expendables",
@@ -1339,7 +1339,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563523076841/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Hangover Part II",
@@ -1352,7 +1352,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835787955118/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Expendables",
@@ -1365,7 +1365,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865506238738/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Hangover Part II",
@@ -1378,7 +1378,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839214600814/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Hangover",
@@ -1391,7 +1391,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578762742250/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Fast And The Furious: Tokyo Drift",
@@ -1404,7 +1404,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580546847404/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Grand Budapest Hotel",
@@ -1417,7 +1417,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1429/UTV-15222-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Heartbreak Kid",
@@ -1430,7 +1430,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15222-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Heartbreak Kid",
@@ -1444,7 +1444,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15222-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Heartbreak Kid",
@@ -1458,7 +1458,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15057-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Hunger Games",
@@ -1471,7 +1471,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15057-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Hunger Games",
@@ -1484,7 +1484,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0710/UTV-15057-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Hunger Games",
@@ -1497,7 +1497,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0850/UTV-15056-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Hobbit: An Unexpected Journey",
@@ -1510,7 +1510,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15056-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Hobbit: An Unexpected Journey",
@@ -1523,7 +1523,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15026-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Hobbit: The Desolation Of Smaug",
@@ -1536,7 +1536,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0654/UTV-15026-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Hobbit: The Desolation Of Smaug",
@@ -1549,7 +1549,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0755/UTV-15089-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Inbetweeners Movie",
@@ -1563,7 +1563,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15089-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Inbetweeners Movie",
@@ -1577,7 +1577,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15191-PI.jpg",
         "fileFormat": "jpg",
         "title": "The House Bunny",
@@ -1590,7 +1590,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1342/UTV-15191-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The House Bunny",
@@ -1604,7 +1604,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15025-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Hangover, Part 3",
@@ -1617,7 +1617,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15025-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Hangover, Part 3",
@@ -1630,7 +1630,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15089-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Inbetweeners Movie",
@@ -1643,7 +1643,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15192-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Incredible Hulk",
@@ -1656,7 +1656,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15191-LI.jpg",
         "fileFormat": "jpg",
         "title": "The House Bunny",
@@ -1670,7 +1670,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15192-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Incredible Hulk",
@@ -1683,7 +1683,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0708/UTV-15027-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Hunger Games: Catching Fire",
@@ -1697,7 +1697,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15027-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Hunger Games: Catching Fire",
@@ -1711,7 +1711,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15120-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Last Exorcism Part II",
@@ -1724,7 +1724,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15120-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Last Exorcism Part II",
@@ -1737,7 +1737,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15027-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Hunger Games: Catching Fire",
@@ -1750,7 +1750,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878150841751/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Heartbreak Kid",
@@ -1763,7 +1763,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845067729595/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Heartbreak Kid",
@@ -1776,7 +1776,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576552967783/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Heartbreak Kid",
@@ -1789,7 +1789,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833782312969/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Inbetweeners Movie",
@@ -1802,7 +1802,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875302866139/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Incredible Hulk",
@@ -1815,7 +1815,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830663835763/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Hunger Games",
@@ -1828,7 +1828,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863099637556/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Hunger Games",
@@ -1841,7 +1841,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566395778385/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Last Exorcism Part II",
@@ -1854,7 +1854,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875184007798/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The House Bunny",
@@ -1867,7 +1867,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842310900814/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The House Bunny",
@@ -1880,7 +1880,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572825128321/pikselss.ism",
         "fileFormat": "ism",
         "title": "The House Bunny",
@@ -1893,7 +1893,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563610458488/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Inbetweeners Movie",
@@ -1906,7 +1906,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863011812710/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Hobbit: An Unexpected Journey",
@@ -1919,7 +1919,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106868763982960/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Last Exorcism Part II",
@@ -1932,7 +1932,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830586317254/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Hobbit: An Unexpected Journey",
@@ -1945,7 +1945,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860130750134/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Hobbit: The Desolation Of Smaug",
@@ -1958,7 +1958,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173557546067138/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Hobbit: The Desolation Of Smaug",
@@ -1971,7 +1971,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121827668825468/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Hobbit: The Desolation Of Smaug",
@@ -1984,7 +1984,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556885950120/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Hunger Games: Catching Fire",
@@ -1997,7 +1997,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121827763683393/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Hunger Games: Catching Fire",
@@ -2010,7 +2010,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860052811542/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Hangover, Part 3",
@@ -2023,7 +2023,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121827532571261/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Hangover, Part 3",
@@ -2036,7 +2036,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860206101087/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Hunger Games: Catching Fire",
@@ -2050,7 +2050,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15056-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Hobbit: An Unexpected Journey",
@@ -2064,7 +2064,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15026-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Hobbit: The Desolation Of Smaug",
@@ -2077,7 +2077,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1633/UTV-15025-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Hangover, Part 3",
@@ -2090,7 +2090,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1344/UTV-15192-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Incredible Hulk",
@@ -2103,7 +2103,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0856/UTV-15120-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Last Exorcism Part II",
@@ -2116,7 +2116,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572149495526/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Incredible Hulk",
@@ -2129,7 +2129,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559891196531/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Hobbit: An Unexpected Journey",
@@ -2142,7 +2142,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559968080702/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Hunger Games",
@@ -2155,7 +2155,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842399946264/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Incredible Hulk",
@@ -2168,7 +2168,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865594561388/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Inbetweeners Movie",
@@ -2181,7 +2181,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835926035670/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Last Exorcism Part II",
@@ -2194,7 +2194,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173557339080706/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Hangover, Part 3",

--- a/test/fixtures/media-items-11.json
+++ b/test/fixtures/media-items-11.json
@@ -13,25 +13,25 @@
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15194%7C%7Csa-team%3AUTV-15031%7C%7Csa-team%3AUTV-15195%7C%7Csa-team%3AUTV-15158&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15194%7C%7Csa-team%3AUTV-15031%7C%7Csa-team%3AUTV-15195%7C%7Csa-team%3AUTV-15158&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15194%7C%7Csa-team%3AUTV-15031%7C%7Csa-team%3AUTV-15195%7C%7Csa-team%3AUTV-15158"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15194%7C%7Csa-team%3AUTV-15031%7C%7Csa-team%3AUTV-15195%7C%7Csa-team%3AUTV-15158&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15194%7C%7Csa-team%3AUTV-15031%7C%7Csa-team%3AUTV-15195%7C%7Csa-team%3AUTV-15158&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15194%7C%7Csa-team%3AUTV-15031%7C%7Csa-team%3AUTV-15195%7C%7Csa-team%3AUTV-15158"
         },
         {
           "totalCount": 60,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15021%7C%7Csa-team%3AUTV-15092%7C%7Csa-team%3AUTV-15030%7C%7Csa-team%3AUTV-15093%7C%7Csa-team%3AUTV-15062%7C%7Csa-team%3AUTV-15123%7C%7Csa-team%3AUTV-BOX-15002%7C%7Csa-team%3AUTV-15094%7C%7Csa-team%3AUTV-15157%7C%7Csa-team%3AUTV-15124&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15021%7C%7Csa-team%3AUTV-15092%7C%7Csa-team%3AUTV-15030%7C%7Csa-team%3AUTV-15093%7C%7Csa-team%3AUTV-15062%7C%7Csa-team%3AUTV-15123%7C%7Csa-team%3AUTV-BOX-15002%7C%7Csa-team%3AUTV-15094%7C%7Csa-team%3AUTV-15157%7C%7Csa-team%3AUTV-15124&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15021%7C%7Csa-team%3AUTV-15092%7C%7Csa-team%3AUTV-15030%7C%7Csa-team%3AUTV-15093%7C%7Csa-team%3AUTV-15062%7C%7Csa-team%3AUTV-15123%7C%7Csa-team%3AUTV-BOX-15002%7C%7Csa-team%3AUTV-15094%7C%7Csa-team%3AUTV-15157%7C%7Csa-team%3AUTV-15124"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15021%7C%7Csa-team%3AUTV-15092%7C%7Csa-team%3AUTV-15030%7C%7Csa-team%3AUTV-15093%7C%7Csa-team%3AUTV-15062%7C%7Csa-team%3AUTV-15123%7C%7Csa-team%3AUTV-BOX-15002%7C%7Csa-team%3AUTV-15094%7C%7Csa-team%3AUTV-15157%7C%7Csa-team%3AUTV-15124&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15021%7C%7Csa-team%3AUTV-15092%7C%7Csa-team%3AUTV-15030%7C%7Csa-team%3AUTV-15093%7C%7Csa-team%3AUTV-15062%7C%7Csa-team%3AUTV-15123%7C%7Csa-team%3AUTV-BOX-15002%7C%7Csa-team%3AUTV-15094%7C%7Csa-team%3AUTV-15157%7C%7Csa-team%3AUTV-15124&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15021%7C%7Csa-team%3AUTV-15092%7C%7Csa-team%3AUTV-15030%7C%7Csa-team%3AUTV-15093%7C%7Csa-team%3AUTV-15062%7C%7Csa-team%3AUTV-15123%7C%7Csa-team%3AUTV-BOX-15002%7C%7Csa-team%3AUTV-15094%7C%7Csa-team%3AUTV-15157%7C%7Csa-team%3AUTV-15124"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15010%7C%7Csa-team%3AUTV-15223%7C%7Csa-team%3AUTV-BOX-15035%7C%7Csa-team%3AUTV-15224%7C%7Csa-team%3AUTV-15028%7C%7Csa-team%3AUTV-15155%7C%7Csa-team%3AUTV-15091%7C%7Csa-team%3AUTV-15059%7C%7Csa-team%3AUTV-15122%7C%7Csa-team%3AUTV-15144&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15010%7C%7Csa-team%3AUTV-15223%7C%7Csa-team%3AUTV-BOX-15035%7C%7Csa-team%3AUTV-15224%7C%7Csa-team%3AUTV-15028%7C%7Csa-team%3AUTV-15155%7C%7Csa-team%3AUTV-15091%7C%7Csa-team%3AUTV-15059%7C%7Csa-team%3AUTV-15122%7C%7Csa-team%3AUTV-15144&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15010%7C%7Csa-team%3AUTV-15223%7C%7Csa-team%3AUTV-BOX-15035%7C%7Csa-team%3AUTV-15224%7C%7Csa-team%3AUTV-15028%7C%7Csa-team%3AUTV-15155%7C%7Csa-team%3AUTV-15091%7C%7Csa-team%3AUTV-15059%7C%7Csa-team%3AUTV-15122%7C%7Csa-team%3AUTV-15144"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15010%7C%7Csa-team%3AUTV-15223%7C%7Csa-team%3AUTV-BOX-15035%7C%7Csa-team%3AUTV-15224%7C%7Csa-team%3AUTV-15028%7C%7Csa-team%3AUTV-15155%7C%7Csa-team%3AUTV-15091%7C%7Csa-team%3AUTV-15059%7C%7Csa-team%3AUTV-15122%7C%7Csa-team%3AUTV-15144&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15010%7C%7Csa-team%3AUTV-15223%7C%7Csa-team%3AUTV-BOX-15035%7C%7Csa-team%3AUTV-15224%7C%7Csa-team%3AUTV-15028%7C%7Csa-team%3AUTV-15155%7C%7Csa-team%3AUTV-15091%7C%7Csa-team%3AUTV-15059%7C%7Csa-team%3AUTV-15122%7C%7Csa-team%3AUTV-15144&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15010%7C%7Csa-team%3AUTV-15223%7C%7Csa-team%3AUTV-BOX-15035%7C%7Csa-team%3AUTV-15224%7C%7Csa-team%3AUTV-15028%7C%7Csa-team%3AUTV-15155%7C%7Csa-team%3AUTV-15091%7C%7Csa-team%3AUTV-15059%7C%7Csa-team%3AUTV-15122%7C%7Csa-team%3AUTV-15144"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0731/UTV-15031-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Turbo",
@@ -324,7 +324,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15031-LI.jpg",
         "fileFormat": "jpg",
         "title": "Turbo",
@@ -338,7 +338,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15031-PI.jpg",
         "fileFormat": "jpg",
         "title": "Turbo",
@@ -351,7 +351,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15194-LI.jpg",
         "fileFormat": "jpg",
         "title": "Tropic Thunder",
@@ -364,7 +364,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15195-LI.jpg",
         "fileFormat": "jpg",
         "title": "Twilight",
@@ -377,7 +377,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1349/UTV-15195-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Twilight",
@@ -391,7 +391,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15195-PI.jpg",
         "fileFormat": "jpg",
         "title": "Twilight",
@@ -405,7 +405,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15194-PI.jpg",
         "fileFormat": "jpg",
         "title": "Tropic Thunder",
@@ -418,7 +418,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1041/UTV-15158-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Up",
@@ -432,7 +432,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15158-PI.jpg",
         "fileFormat": "jpg",
         "title": "Up",
@@ -445,7 +445,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572506489733/pikselss.ism",
         "fileFormat": "ism",
         "title": "Tropic Thunder",
@@ -458,7 +458,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872692385189/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Up",
@@ -471,7 +471,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875468576351/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Tropic Thunder",
@@ -484,7 +484,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572666433271/pikselss.ism",
         "fileFormat": "ism",
         "title": "Twilight",
@@ -497,7 +497,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842701779544/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Twilight",
@@ -510,7 +510,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875546032663/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Twilight",
@@ -523,7 +523,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839475648864/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Up",
@@ -536,7 +536,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828199964616/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Turbo",
@@ -549,7 +549,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860661510557/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Turbo",
@@ -562,7 +562,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1347/UTV-15194-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Tropic Thunder",
@@ -575,7 +575,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15158-LI.jpg",
         "fileFormat": "jpg",
         "title": "Up",
@@ -588,7 +588,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842622337452/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Tropic Thunder",
@@ -601,7 +601,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569687282626/pikselss.ism",
         "fileFormat": "ism",
         "title": "Up",
@@ -614,7 +614,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173557734710881/pikselss.ism",
         "fileFormat": "ism",
         "title": "Turbo",
@@ -627,7 +627,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15124-LI.jpg",
         "fileFormat": "jpg",
         "title": "Tron: Legacy",
@@ -640,7 +640,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0904/UTV-15124-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Tron: Legacy",
@@ -654,7 +654,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15124-PI.jpg",
         "fileFormat": "jpg",
         "title": "Tron: Legacy",
@@ -668,7 +668,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15021-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Wolf of Wall Street",
@@ -681,7 +681,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1707/UTV-BOX-15021-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Wolf of Wall Street",
@@ -694,7 +694,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15021-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Wolf of Wall Street",
@@ -708,7 +708,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15002-PI.jpg",
         "fileFormat": "jpg",
         "title": "Transformers: Age Of Extinction",
@@ -721,7 +721,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15002-LI.jpg",
         "fileFormat": "jpg",
         "title": "Transformers: Age Of Extinction",
@@ -734,7 +734,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15094-LI.jpg",
         "fileFormat": "jpg",
         "title": "Transformers: Dark of the Moon",
@@ -748,7 +748,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15092-PI.jpg",
         "fileFormat": "jpg",
         "title": "Thor",
@@ -762,7 +762,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15094-PI.jpg",
         "fileFormat": "jpg",
         "title": "Transformers: Dark of the Moon",
@@ -775,7 +775,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0803/UTV-15094-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Transformers: Dark of the Moon",
@@ -788,7 +788,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15092-LI.jpg",
         "fileFormat": "jpg",
         "title": "Thor",
@@ -802,7 +802,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15123-PI.jpg",
         "fileFormat": "jpg",
         "title": "Toy Story 3",
@@ -815,7 +815,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15123-LI.jpg",
         "fileFormat": "jpg",
         "title": "Toy Story 3",
@@ -828,7 +828,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15030-LI.jpg",
         "fileFormat": "jpg",
         "title": "Thor: The Dark World",
@@ -841,7 +841,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0721/UTV-15030-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Thor: The Dark World",
@@ -855,7 +855,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15157-PI.jpg",
         "fileFormat": "jpg",
         "title": "Transformers: Revenge Of The Fallen",
@@ -868,7 +868,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1039/UTV-15157-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Transformers: Revenge Of The Fallen",
@@ -882,7 +882,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15093-PI.jpg",
         "fileFormat": "jpg",
         "title": "Tinker, Tailor, Soldier, Spy",
@@ -895,7 +895,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15093-LI.jpg",
         "fileFormat": "jpg",
         "title": "Tinker, Tailor, Soldier, Spy",
@@ -908,7 +908,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0801/UTV-15093-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Tinker, Tailor, Soldier, Spy",
@@ -921,7 +921,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0714/UTV-15062-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Total Recall",
@@ -934,7 +934,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15157-LI.jpg",
         "fileFormat": "jpg",
         "title": "Transformers: Revenge Of The Fallen",
@@ -948,7 +948,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15062-PI.jpg",
         "fileFormat": "jpg",
         "title": "Total Recall",
@@ -961,7 +961,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869222141856/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Tron: Legacy",
@@ -974,7 +974,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836367039377/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Tron: Legacy",
@@ -987,7 +987,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565785997119/pikselss.ism",
         "fileFormat": "ism",
         "title": "Tron: Legacy",
@@ -1000,7 +1000,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569438156744/pikselss.ism",
         "fileFormat": "ism",
         "title": "Transformers: Revenge Of The Fallen",
@@ -1013,7 +1013,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563825697207/pikselss.ism",
         "fileFormat": "ism",
         "title": "Transformers: Dark of the Moon",
@@ -1026,7 +1026,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869143851042/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Toy Story 3",
@@ -1039,7 +1039,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834107790222/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Transformers: Dark of the Moon",
@@ -1052,7 +1052,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106866084598084/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Transformers: Dark of the Moon",
@@ -1065,7 +1065,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566805436915/pikselss.ism",
         "fileFormat": "ism",
         "title": "Toy Story 3",
@@ -1078,7 +1078,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833943078355/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Thor",
@@ -1091,7 +1091,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828091104541/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Thor: The Dark World",
@@ -1104,7 +1104,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860584206712/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Thor: The Dark World",
@@ -1117,7 +1117,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173557659952097/pikselss.ism",
         "fileFormat": "ism",
         "title": "Thor: The Dark World",
@@ -1130,7 +1130,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880921797473/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Transformers: Age Of Extinction",
@@ -1143,7 +1143,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578544846334/pikselss.ism",
         "fileFormat": "ism",
         "title": "Transformers: Age Of Extinction",
@@ -1156,7 +1156,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563448881443/pikselss.ism",
         "fileFormat": "ism",
         "title": "Tinker, Tailor, Soldier, Spy",
@@ -1169,7 +1169,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865995624802/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Tinker, Tailor, Soldier, Spy",
@@ -1182,7 +1182,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563335753139/pikselss.ism",
         "fileFormat": "ism",
         "title": "Thor",
@@ -1195,7 +1195,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865773634143/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Thor",
@@ -1208,7 +1208,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834027852594/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Tinker, Tailor, Soldier, Spy",
@@ -1221,7 +1221,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863421248741/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Total Recall",
@@ -1234,7 +1234,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882788055642/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Wolf of Wall Street",
@@ -1247,7 +1247,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849655034929/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Wolf of Wall Street",
@@ -1260,7 +1260,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0902/UTV-15123-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Toy Story 3",
@@ -1273,7 +1273,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0759/UTV-15092-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Thor",
@@ -1286,7 +1286,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1311/UTV-BOX-15002-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Transformers: Age Of Extinction",
@@ -1300,7 +1300,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15030-PI.jpg",
         "fileFormat": "jpg",
         "title": "Thor: The Dark World",
@@ -1313,7 +1313,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15062-LI.jpg",
         "fileFormat": "jpg",
         "title": "Total Recall",
@@ -1326,7 +1326,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872600130712/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Transformers: Revenge Of The Fallen",
@@ -1339,7 +1339,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839384973286/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Transformers: Revenge Of The Fallen",
@@ -1352,7 +1352,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836286078544/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Toy Story 3",
@@ -1365,7 +1365,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830974396066/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Total Recall",
@@ -1378,7 +1378,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561023040161/pikselss.ism",
         "fileFormat": "ism",
         "title": "Total Recall",
@@ -1391,7 +1391,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847694826505/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Transformers: Age Of Extinction",
@@ -1404,7 +1404,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580832541008/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Wolf of Wall Street",
@@ -1418,7 +1418,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15224-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Simpsons Movie",
@@ -1431,7 +1431,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0714/UTV-15028-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Smurfs 2 ",
@@ -1445,7 +1445,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15028-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Smurfs 2 ",
@@ -1458,7 +1458,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15224-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Simpsons Movie",
@@ -1472,7 +1472,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15122-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Twilight Saga: Eclipse",
@@ -1485,7 +1485,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15122-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Twilight Saga: Eclipse",
@@ -1498,7 +1498,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15028-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Smurfs 2 ",
@@ -1511,7 +1511,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1328/UTV-BOX-15010-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Purge: Anarchy",
@@ -1524,7 +1524,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15010-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Purge: Anarchy",
@@ -1538,7 +1538,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15010-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Purge: Anarchy",
@@ -1551,7 +1551,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15091-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Twilight Saga: Breaking Dawn, Part 1",
@@ -1564,7 +1564,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1045/UTV-15155-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Time Traveler's Wife",
@@ -1577,7 +1577,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15155-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Time Traveler's Wife",
@@ -1591,7 +1591,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15035-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Raid 2: Berandal",
@@ -1604,7 +1604,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0959/UTV-15091-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Twilight Saga: Breaking Dawn, Part 1",
@@ -1618,7 +1618,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15091-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Twilight Saga: Breaking Dawn, Part 1",
@@ -1631,7 +1631,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15059-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Twilight Saga: Breaking Dawn, Part 2",
@@ -1645,7 +1645,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15059-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Twilight Saga: Breaking Dawn, Part 2",
@@ -1658,7 +1658,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15144-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Twilight Saga: New Moon",
@@ -1671,7 +1671,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1035/UTV-15144-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Twilight Saga: New Moon",
@@ -1684,7 +1684,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15035-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Raid 2: Berandal",
@@ -1697,7 +1697,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1431/UTV-15223-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Pursuit Of Happyness",
@@ -1711,7 +1711,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15223-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Pursuit Of Happyness",
@@ -1724,7 +1724,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121827881323182/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Smurfs 2 ",
@@ -1737,7 +1737,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845223096251/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Simpsons Movie",
@@ -1750,7 +1750,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173557060340018/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Smurfs 2 ",
@@ -1763,7 +1763,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860293903359/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Smurfs 2 ",
@@ -1776,7 +1776,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173568392763502/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Twilight Saga: New Moon",
@@ -1789,7 +1789,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838282822967/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Twilight Saga: New Moon",
@@ -1802,7 +1802,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106871316379624/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Twilight Saga: New Moon",
@@ -1815,7 +1815,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869051146017/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Twilight Saga: Eclipse",
@@ -1828,7 +1828,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836082861262/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Twilight Saga: Eclipse",
@@ -1841,7 +1841,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566717772665/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Twilight Saga: Eclipse",
@@ -1854,7 +1854,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833862958867/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Twilight Saga: Breaking Dawn, Part 1",
@@ -1867,7 +1867,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563080840931/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Twilight Saga: Breaking Dawn, Part 1",
@@ -1880,7 +1880,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872478148361/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Time Traveler's Wife",
@@ -1893,7 +1893,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839296301696/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Time Traveler's Wife",
@@ -1906,7 +1906,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173560618836967/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Twilight Saga: Breaking Dawn, Part 2",
@@ -1919,7 +1919,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881935290376/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Purge: Anarchy",
@@ -1932,7 +1932,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576792059677/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Pursuit Of Happyness",
@@ -1945,7 +1945,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878237791761/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Pursuit Of Happyness",
@@ -1958,7 +1958,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883876470779/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Raid 2: Berandal",
@@ -1971,7 +1971,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850925694145/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Raid 2: Berandal",
@@ -1984,7 +1984,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1432/UTV-15224-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Simpsons Movie",
@@ -1997,7 +1997,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0900/UTV-15122-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Twilight Saga: Eclipse",
@@ -2010,7 +2010,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0712/UTV-15059-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Twilight Saga: Breaking Dawn, Part 2",
@@ -2024,7 +2024,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15144-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Twilight Saga: New Moon",
@@ -2038,7 +2038,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15155-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Time Traveler's Wife",
@@ -2051,7 +2051,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15223-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Pursuit Of Happyness",
@@ -2064,7 +2064,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569360919443/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Time Traveler's Wife",
@@ -2077,7 +2077,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173575442074469/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Simpsons Movie",
@@ -2090,7 +2090,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878312205306/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Simpsons Movie",
@@ -2103,7 +2103,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865674954974/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Twilight Saga: Breaking Dawn, Part 1",
@@ -2116,7 +2116,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863248731528/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Twilight Saga: Breaking Dawn, Part 2",
@@ -2129,7 +2129,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830820069058/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Twilight Saga: Breaking Dawn, Part 2",
@@ -2142,7 +2142,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848589501945/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Purge: Anarchy",
@@ -2155,7 +2155,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578933289004/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Purge: Anarchy",
@@ -2168,7 +2168,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845145193954/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Pursuit Of Happyness",
@@ -2181,7 +2181,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173581072710989/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Raid 2: Berandal",

--- a/test/fixtures/media-items-12.json
+++ b/test/fixtures/media-items-12.json
@@ -12,17 +12,17 @@
           "totalCount": 23,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15160%7C%7Csa-team%3AUTV-BOX-15004%7C%7Csa-team%3AUTV-15095%7C%7Csa-team%3AUTV-15197&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15160%7C%7Csa-team%3AUTV-BOX-15004%7C%7Csa-team%3AUTV-15095%7C%7Csa-team%3AUTV-15197&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15160%7C%7Csa-team%3AUTV-BOX-15004%7C%7Csa-team%3AUTV-15095%7C%7Csa-team%3AUTV-15197"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15160%7C%7Csa-team%3AUTV-BOX-15004%7C%7Csa-team%3AUTV-15095%7C%7Csa-team%3AUTV-15197&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15160%7C%7Csa-team%3AUTV-BOX-15004%7C%7Csa-team%3AUTV-15095%7C%7Csa-team%3AUTV-15197&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15160%7C%7Csa-team%3AUTV-BOX-15004%7C%7Csa-team%3AUTV-15095%7C%7Csa-team%3AUTV-15197"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15018%7C%7Csa-team%3AUTV-15196%7C%7Csa-team%3AUTV-15126%7C%7Csa-team%3AUTV-15063%7C%7Csa-team%3AUTV-BOX-15039%7C%7Csa-team%3AUTV-15159%7C%7Csa-team%3AUTV-15225%7C%7Csa-team%3AUTV-15029%7C%7Csa-team%3AUTV-BOX-15022%7C%7Csa-team%3AUTV-15032&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15018%7C%7Csa-team%3AUTV-15196%7C%7Csa-team%3AUTV-15126%7C%7Csa-team%3AUTV-15063%7C%7Csa-team%3AUTV-BOX-15039%7C%7Csa-team%3AUTV-15159%7C%7Csa-team%3AUTV-15225%7C%7Csa-team%3AUTV-15029%7C%7Csa-team%3AUTV-BOX-15022%7C%7Csa-team%3AUTV-15032&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15018%7C%7Csa-team%3AUTV-15196%7C%7Csa-team%3AUTV-15126%7C%7Csa-team%3AUTV-15063%7C%7Csa-team%3AUTV-BOX-15039%7C%7Csa-team%3AUTV-15159%7C%7Csa-team%3AUTV-15225%7C%7Csa-team%3AUTV-15029%7C%7Csa-team%3AUTV-BOX-15022%7C%7Csa-team%3AUTV-15032"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15018%7C%7Csa-team%3AUTV-15196%7C%7Csa-team%3AUTV-15126%7C%7Csa-team%3AUTV-15063%7C%7Csa-team%3AUTV-BOX-15039%7C%7Csa-team%3AUTV-15159%7C%7Csa-team%3AUTV-15225%7C%7Csa-team%3AUTV-15029%7C%7Csa-team%3AUTV-BOX-15022%7C%7Csa-team%3AUTV-15032&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15018%7C%7Csa-team%3AUTV-15196%7C%7Csa-team%3AUTV-15126%7C%7Csa-team%3AUTV-15063%7C%7Csa-team%3AUTV-BOX-15039%7C%7Csa-team%3AUTV-15159%7C%7Csa-team%3AUTV-15225%7C%7Csa-team%3AUTV-15029%7C%7Csa-team%3AUTV-BOX-15022%7C%7Csa-team%3AUTV-15032&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15018%7C%7Csa-team%3AUTV-15196%7C%7Csa-team%3AUTV-15126%7C%7Csa-team%3AUTV-15063%7C%7Csa-team%3AUTV-BOX-15039%7C%7Csa-team%3AUTV-15159%7C%7Csa-team%3AUTV-15225%7C%7Csa-team%3AUTV-15029%7C%7Csa-team%3AUTV-BOX-15022%7C%7Csa-team%3AUTV-15032"
         }
       ]
     }
@@ -191,7 +191,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1354/UTV-15197-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Yes Man",
@@ -205,7 +205,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15004-PI.jpg",
         "fileFormat": "jpg",
         "title": "X-Men: Days Of Future Past",
@@ -218,7 +218,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15160-LI.jpg",
         "fileFormat": "jpg",
         "title": "X-Men Origins: Wolverine",
@@ -232,7 +232,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15095-PI.jpg",
         "fileFormat": "jpg",
         "title": "X-Men: First class",
@@ -245,7 +245,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0804/UTV-15095-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "X-Men: First class",
@@ -258,7 +258,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573155750163/pikselss.ism",
         "fileFormat": "ism",
         "title": "Yes Man",
@@ -271,7 +271,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875724628686/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Yes Man",
@@ -284,7 +284,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842872951252/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Yes Man",
@@ -297,7 +297,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847980281499/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "X-Men: Days Of Future Past",
@@ -310,7 +310,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872972797390/piksel.mpd",
         "fileFormat": "mpd",
         "title": "X-Men Origins: Wolverine",
@@ -323,7 +323,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563975964640/pikselss.ism",
         "fileFormat": "ism",
         "title": "X-Men: First class",
@@ -336,7 +336,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839702024422/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "X-Men Origins: Wolverine",
@@ -349,7 +349,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569925052426/pikselss.ism",
         "fileFormat": "ism",
         "title": "X-Men Origins: Wolverine",
@@ -362,7 +362,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106866162756180/piksel.mpd",
         "fileFormat": "mpd",
         "title": "X-Men: First class",
@@ -375,7 +375,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834190856261/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "X-Men: First class",
@@ -388,7 +388,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15197-LI.jpg",
         "fileFormat": "jpg",
         "title": "Yes Man",
@@ -402,7 +402,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15197-PI.jpg",
         "fileFormat": "jpg",
         "title": "Yes Man",
@@ -415,7 +415,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1318/UTV-BOX-15004-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "X-Men: Days Of Future Past",
@@ -428,7 +428,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15004-LI.jpg",
         "fileFormat": "jpg",
         "title": "X-Men: Days Of Future Past",
@@ -441,7 +441,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1047/UTV-15160-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "X-Men Origins: Wolverine",
@@ -455,7 +455,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15160-PI.jpg",
         "fileFormat": "jpg",
         "title": "X-Men Origins: Wolverine",
@@ -468,7 +468,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881225723572/piksel.mpd",
         "fileFormat": "mpd",
         "title": "X-Men: Days Of Future Past",
@@ -481,7 +481,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578847338821/pikselss.ism",
         "fileFormat": "ism",
         "title": "X-Men: Days Of Future Past",
@@ -494,7 +494,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1350/UTV-BOX-15022-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "World War Z",
@@ -508,7 +508,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15022-PI.jpg",
         "fileFormat": "jpg",
         "title": "World War Z",
@@ -521,7 +521,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15022-LI.jpg",
         "fileFormat": "jpg",
         "title": "World War Z",
@@ -534,7 +534,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15032-LI.jpg",
         "fileFormat": "jpg",
         "title": "Wreck-It Ralph",
@@ -547,7 +547,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0831/UTV-BOX-15039-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Warm Bodies",
@@ -560,7 +560,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15063-LI.jpg",
         "fileFormat": "jpg",
         "title": "War Horse",
@@ -574,7 +574,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15063-PI.jpg",
         "fileFormat": "jpg",
         "title": "War Horse",
@@ -587,7 +587,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0931/UTV-15063-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "War Horse",
@@ -600,7 +600,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1702/UTV-BOX-15018-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Vampire Academy: Blood Sisters",
@@ -613,7 +613,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15196-LI.jpg",
         "fileFormat": "jpg",
         "title": "Vantage Point",
@@ -626,7 +626,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1351/UTV-15196-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Vantage Point",
@@ -640,7 +640,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15039-PI.jpg",
         "fileFormat": "jpg",
         "title": "Warm Bodies",
@@ -654,7 +654,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15032-PI.jpg",
         "fileFormat": "jpg",
         "title": "Wreck-It Ralph",
@@ -667,7 +667,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0738/UTV-15032-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Wreck-It Ralph",
@@ -681,7 +681,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15159-PI.jpg",
         "fileFormat": "jpg",
         "title": "Watchmen",
@@ -694,7 +694,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15159-LI.jpg",
         "fileFormat": "jpg",
         "title": "Watchmen",
@@ -707,7 +707,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1042/UTV-15159-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Watchmen",
@@ -721,7 +721,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15225-PI.jpg",
         "fileFormat": "jpg",
         "title": "Wild Hogs",
@@ -734,7 +734,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15225-LI.jpg",
         "fileFormat": "jpg",
         "title": "Wild Hogs",
@@ -747,7 +747,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15126-LI.jpg",
         "fileFormat": "jpg",
         "title": "Wall Street: Money Never Sleeps",
@@ -761,7 +761,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15126-PI.jpg",
         "fileFormat": "jpg",
         "title": "Wall Street: Money Never Sleeps",
@@ -774,7 +774,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0719/UTV-15029-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Wolverine",
@@ -787,7 +787,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15029-LI.jpg",
         "fileFormat": "jpg",
         "title": "Wolverine",
@@ -801,7 +801,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15029-PI.jpg",
         "fileFormat": "jpg",
         "title": "Wolverine",
@@ -814,7 +814,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173557809642066/pikselss.ism",
         "fileFormat": "ism",
         "title": "Wreck-It Ralph",
@@ -827,7 +827,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860751126912/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Wreck-It Ralph",
@@ -840,7 +840,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565993912468/pikselss.ism",
         "fileFormat": "ism",
         "title": "Wall Street: Money Never Sleeps",
@@ -853,7 +853,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561272580779/pikselss.ism",
         "fileFormat": "ism",
         "title": "War Horse",
@@ -866,7 +866,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831050470788/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "War Horse",
@@ -879,7 +879,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849291176994/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Vampire Academy: Blood Sisters",
@@ -892,7 +892,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882538791937/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Vampire Academy: Blood Sisters",
@@ -905,7 +905,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863497266314/piksel.mpd",
         "fileFormat": "mpd",
         "title": "War Horse",
@@ -918,7 +918,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836450085092/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Wall Street: Money Never Sleeps",
@@ -931,7 +931,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878392786640/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Wild Hogs",
@@ -944,7 +944,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845300110090/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Wild Hogs",
@@ -957,7 +957,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576280580121/pikselss.ism",
         "fileFormat": "ism",
         "title": "Wild Hogs",
@@ -970,7 +970,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569764659466/pikselss.ism",
         "fileFormat": "ism",
         "title": "Watchmen",
@@ -983,7 +983,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572996720365/pikselss.ism",
         "fileFormat": "ism",
         "title": "Vantage Point",
@@ -996,7 +996,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875636203582/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Vantage Point",
@@ -1009,7 +1009,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872897594053/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Watchmen",
@@ -1022,7 +1022,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173557263610213/pikselss.ism",
         "fileFormat": "ism",
         "title": "Wolverine",
@@ -1035,7 +1035,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860509013432/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Wolverine",
@@ -1048,7 +1048,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121827977969472/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Wolverine",
@@ -1061,7 +1061,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579942008616/pikselss.ism",
         "fileFormat": "ism",
         "title": "World War Z",
@@ -1074,7 +1074,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851229629420/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Warm Bodies",
@@ -1087,7 +1087,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884212783969/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Warm Bodies",
@@ -1101,7 +1101,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15018-PI.jpg",
         "fileFormat": "jpg",
         "title": "Vampire Academy: Blood Sisters",
@@ -1114,7 +1114,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15018-LI.jpg",
         "fileFormat": "jpg",
         "title": "Vampire Academy: Blood Sisters",
@@ -1127,7 +1127,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15039-LI.jpg",
         "fileFormat": "jpg",
         "title": "Warm Bodies",
@@ -1141,7 +1141,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15196-PI.jpg",
         "fileFormat": "jpg",
         "title": "Vantage Point",
@@ -1154,7 +1154,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0927/UTV-15126-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Wall Street: Money Never Sleeps",
@@ -1167,7 +1167,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580097806809/pikselss.ism",
         "fileFormat": "ism",
         "title": "Vampire Academy: Blood Sisters",
@@ -1180,7 +1180,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869301860147/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Wall Street: Money Never Sleeps",
@@ -1193,7 +1193,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828303529928/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Wreck-It Ralph",
@@ -1206,7 +1206,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839561562667/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Watchmen",
@@ -1219,7 +1219,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842791658049/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Vantage Point",
@@ -1232,7 +1232,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582089015118/pikselss.ism",
         "fileFormat": "ism",
         "title": "Warm Bodies",
@@ -1245,7 +1245,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882874092138/piksel.mpd",
         "fileFormat": "mpd",
         "title": "World War Z",
@@ -1258,7 +1258,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849746166153/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "World War Z",

--- a/test/fixtures/media-items-2.json
+++ b/test/fixtures/media-items-2.json
@@ -13,25 +13,25 @@
           "totalCount": 53,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15066%7C%7Csa-team%3AUTV-15132%7C%7Csa-team%3AUTV-15165%7C%7Csa-team%3AUTV-BOX-15000%7C%7Csa-team%3ADEMO-123%7C%7Csa-team%3AUTV-15227%7C%7Csa-team%3AUTV-15228%7C%7Csa-team%3AUTV-15229%7C%7Csa-team%3AUTV-15230%7C%7Csa-team%3AUTV-15036&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15066%7C%7Csa-team%3AUTV-15132%7C%7Csa-team%3AUTV-15165%7C%7Csa-team%3AUTV-BOX-15000%7C%7Csa-team%3ADEMO-123%7C%7Csa-team%3AUTV-15227%7C%7Csa-team%3AUTV-15228%7C%7Csa-team%3AUTV-15229%7C%7Csa-team%3AUTV-15230%7C%7Csa-team%3AUTV-15036&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15066%7C%7Csa-team%3AUTV-15132%7C%7Csa-team%3AUTV-15165%7C%7Csa-team%3AUTV-BOX-15000%7C%7Csa-team%3ADEMO-123%7C%7Csa-team%3AUTV-15227%7C%7Csa-team%3AUTV-15228%7C%7Csa-team%3AUTV-15229%7C%7Csa-team%3AUTV-15230%7C%7Csa-team%3AUTV-15036"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15066%7C%7Csa-team%3AUTV-15132%7C%7Csa-team%3AUTV-15165%7C%7Csa-team%3AUTV-BOX-15000%7C%7Csa-team%3ADEMO-123%7C%7Csa-team%3AUTV-15227%7C%7Csa-team%3AUTV-15228%7C%7Csa-team%3AUTV-15229%7C%7Csa-team%3AUTV-15230%7C%7Csa-team%3AUTV-15036&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15066%7C%7Csa-team%3AUTV-15132%7C%7Csa-team%3AUTV-15165%7C%7Csa-team%3AUTV-BOX-15000%7C%7Csa-team%3ADEMO-123%7C%7Csa-team%3AUTV-15227%7C%7Csa-team%3AUTV-15228%7C%7Csa-team%3AUTV-15229%7C%7Csa-team%3AUTV-15230%7C%7Csa-team%3AUTV-15036&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15066%7C%7Csa-team%3AUTV-15132%7C%7Csa-team%3AUTV-15165%7C%7Csa-team%3AUTV-BOX-15000%7C%7Csa-team%3ADEMO-123%7C%7Csa-team%3AUTV-15227%7C%7Csa-team%3AUTV-15228%7C%7Csa-team%3AUTV-15229%7C%7Csa-team%3AUTV-15230%7C%7Csa-team%3AUTV-15036"
         },
         {
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15005%7C%7Csa-team%3AUTV-15134%7C%7Csa-team%3AUTV-BOX-15007%7C%7Csa-team%3AUTV-BOX-15013&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15005%7C%7Csa-team%3AUTV-15134%7C%7Csa-team%3AUTV-BOX-15007%7C%7Csa-team%3AUTV-BOX-15013&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15005%7C%7Csa-team%3AUTV-15134%7C%7Csa-team%3AUTV-BOX-15007%7C%7Csa-team%3AUTV-BOX-15013"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15005%7C%7Csa-team%3AUTV-15134%7C%7Csa-team%3AUTV-BOX-15007%7C%7Csa-team%3AUTV-BOX-15013&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15005%7C%7Csa-team%3AUTV-15134%7C%7Csa-team%3AUTV-BOX-15007%7C%7Csa-team%3AUTV-BOX-15013&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15005%7C%7Csa-team%3AUTV-15134%7C%7Csa-team%3AUTV-BOX-15007%7C%7Csa-team%3AUTV-BOX-15013"
         },
         {
           "totalCount": 57,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3ACaracol-001%7C%7Csa-team%3AUTV-15098%7C%7Csa-team%3AUTV-15133%7C%7Csa-team%3AUTV-15004%7C%7Csa-team%3AUTV-15166%7C%7Csa-team%3AUTV-BOX-15043%7C%7Csa-team%3AUTV-BOX-15044%7C%7Csa-team%3AUTV-15232%7C%7Csa-team%3AUTV-15099%7C%7Csa-team%3AUTV-15101&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3ACaracol-001%7C%7Csa-team%3AUTV-15098%7C%7Csa-team%3AUTV-15133%7C%7Csa-team%3AUTV-15004%7C%7Csa-team%3AUTV-15166%7C%7Csa-team%3AUTV-BOX-15043%7C%7Csa-team%3AUTV-BOX-15044%7C%7Csa-team%3AUTV-15232%7C%7Csa-team%3AUTV-15099%7C%7Csa-team%3AUTV-15101&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3ACaracol-001%7C%7Csa-team%3AUTV-15098%7C%7Csa-team%3AUTV-15133%7C%7Csa-team%3AUTV-15004%7C%7Csa-team%3AUTV-15166%7C%7Csa-team%3AUTV-BOX-15043%7C%7Csa-team%3AUTV-BOX-15044%7C%7Csa-team%3AUTV-15232%7C%7Csa-team%3AUTV-15099%7C%7Csa-team%3AUTV-15101"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3ACaracol-001%7C%7Csa-team%3AUTV-15098%7C%7Csa-team%3AUTV-15133%7C%7Csa-team%3AUTV-15004%7C%7Csa-team%3AUTV-15166%7C%7Csa-team%3AUTV-BOX-15043%7C%7Csa-team%3AUTV-BOX-15044%7C%7Csa-team%3AUTV-15232%7C%7Csa-team%3AUTV-15099%7C%7Csa-team%3AUTV-15101&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3ACaracol-001%7C%7Csa-team%3AUTV-15098%7C%7Csa-team%3AUTV-15133%7C%7Csa-team%3AUTV-15004%7C%7Csa-team%3AUTV-15166%7C%7Csa-team%3AUTV-BOX-15043%7C%7Csa-team%3AUTV-BOX-15044%7C%7Csa-team%3AUTV-15232%7C%7Csa-team%3AUTV-15099%7C%7Csa-team%3AUTV-15101&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3ACaracol-001%7C%7Csa-team%3AUTV-15098%7C%7Csa-team%3AUTV-15133%7C%7Csa-team%3AUTV-15004%7C%7Csa-team%3AUTV-15166%7C%7Csa-team%3AUTV-BOX-15043%7C%7Csa-team%3AUTV-BOX-15044%7C%7Csa-team%3AUTV-15232%7C%7Csa-team%3AUTV-15099%7C%7Csa-team%3AUTV-15101"
         }
       ]
     }
@@ -310,7 +310,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/9/21/landscape/UTV-15095-LI.jpg",
         "fileFormat": "jpg",
         "title": "capturedvideo-21stSep2015-5-04pm",
@@ -324,7 +324,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15229-PI.jpg",
         "fileFormat": "jpg",
         "title": "Chicken Little",
@@ -337,7 +337,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0651/UTV-15036-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Chronicle",
@@ -351,7 +351,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15036-PI.jpg",
         "fileFormat": "jpg",
         "title": "Chronicle",
@@ -364,7 +364,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15066-LI.jpg",
         "fileFormat": "jpg",
         "title": "Bridesmaids",
@@ -378,7 +378,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15066-PI.jpg",
         "fileFormat": "jpg",
         "title": "Bridesmaids",
@@ -391,7 +391,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15000-LI.jpg",
         "fileFormat": "jpg",
         "title": "Captain America: The Winter Soldier",
@@ -404,7 +404,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1219/UTV-BOX-15000-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Captain America: The Winter Soldier",
@@ -417,7 +417,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0720/UTV-15066-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Bridesmaids",
@@ -430,7 +430,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1052/UTV-15165-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Burn After Reading",
@@ -444,7 +444,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15165-PI.jpg",
         "fileFormat": "jpg",
         "title": "Burn After Reading",
@@ -458,7 +458,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15132-PI.jpg",
         "fileFormat": "jpg",
         "title": "Brüno",
@@ -471,7 +471,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0946/UTV-15132-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Brüno",
@@ -484,7 +484,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15132-LI.jpg",
         "fileFormat": "jpg",
         "title": "Brüno",
@@ -498,7 +498,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15228-PI.jpg",
         "fileFormat": "jpg",
         "title": "Casino Royale",
@@ -511,7 +511,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15165-LI.jpg",
         "fileFormat": "jpg",
         "title": "Burn After Reading",
@@ -524,7 +524,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567056036645/pikselss.ism",
         "fileFormat": "ism",
         "title": "Brüno",
@@ -537,7 +537,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576391806141/pikselss.ism",
         "fileFormat": "ism",
         "title": "Cars",
@@ -550,7 +550,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845375567214/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Cars",
@@ -563,7 +563,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/09/21/1605/capturedvideo-21stSep2015-5-04pm.ism",
         "fileFormat": "ism",
         "title": "capturedvideo-21stSep2015-5-04pm",
@@ -576,7 +576,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576713591543/pikselss.ism",
         "fileFormat": "ism",
         "title": "Chicken Little",
@@ -589,7 +589,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873288769246/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Burn After Reading",
@@ -602,7 +602,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840060401211/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Burn After Reading",
@@ -615,7 +615,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861259527222/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Chronicle",
@@ -628,7 +628,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570524753756/pikselss.ism",
         "fileFormat": "ism",
         "title": "Burn After Reading",
@@ -641,7 +641,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577904627279/pikselss.ism",
         "fileFormat": "ism",
         "title": "Captain America: The Winter Soldier",
@@ -654,7 +654,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863750116816/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Bridesmaids",
@@ -667,7 +667,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847539746533/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Captain America: The Winter Soldier",
@@ -680,7 +680,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880744877912/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Captain America: The Winter Soldier",
@@ -693,7 +693,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878850599395/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Children Of Men",
@@ -706,7 +706,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845654471925/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Chicken Little",
@@ -719,7 +719,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878773954633/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Chicken Little",
@@ -732,7 +732,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558778554415/pikselss.ism",
         "fileFormat": "ism",
         "title": "Chronicle",
@@ -745,7 +745,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869947896198/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Brüno",
@@ -758,7 +758,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828786820677/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Chronicle",
@@ -771,7 +771,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845791917611/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Children Of Men",
@@ -784,7 +784,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878695813569/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Casino Royale",
@@ -797,7 +797,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576638941751/pikselss.ism",
         "fileFormat": "ism",
         "title": "Casino Royale",
@@ -811,7 +811,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15230-PI.jpg",
         "fileFormat": "jpg",
         "title": "Children Of Men",
@@ -824,7 +824,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15229-LI.jpg",
         "fileFormat": "jpg",
         "title": "Chicken Little",
@@ -837,7 +837,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15230-LI.jpg",
         "fileFormat": "jpg",
         "title": "Children Of Men",
@@ -850,7 +850,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1441/UTV-15230-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Children Of Men",
@@ -864,7 +864,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15000-PI.jpg",
         "fileFormat": "jpg",
         "title": "Captain America: The Winter Soldier",
@@ -877,7 +877,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15227-LI.jpg",
         "fileFormat": "jpg",
         "title": "Cars",
@@ -890,7 +890,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15036-LI.jpg",
         "fileFormat": "jpg",
         "title": "Chronicle",
@@ -904,7 +904,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15227-PI.jpg",
         "fileFormat": "jpg",
         "title": "Cars",
@@ -917,7 +917,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15228-LI.jpg",
         "fileFormat": "jpg",
         "title": "Casino Royale",
@@ -930,7 +930,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831307246774/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Bridesmaids",
@@ -943,7 +943,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837068636647/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Brüno",
@@ -956,7 +956,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576878934069/pikselss.ism",
         "fileFormat": "ism",
         "title": "Children Of Men",
@@ -969,7 +969,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561812179021/pikselss.ism",
         "fileFormat": "ism",
         "title": "Bridesmaids",
@@ -982,7 +982,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106878608582179/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Cars",
@@ -995,7 +995,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845450176238/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Casino Royale",
@@ -1008,7 +1008,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1027/UTV-15134-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "District 9",
@@ -1021,7 +1021,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15134-LI.jpg",
         "fileFormat": "jpg",
         "title": "District 9",
@@ -1035,7 +1035,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15134-PI.jpg",
         "fileFormat": "jpg",
         "title": "District 9",
@@ -1048,7 +1048,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1700/UTV-BOX-15013-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Dracula Untold",
@@ -1061,7 +1061,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15013-LI.jpg",
         "fileFormat": "jpg",
         "title": "Dracula Untold",
@@ -1075,7 +1075,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15013-PI.jpg",
         "fileFormat": "jpg",
         "title": "Dracula Untold",
@@ -1089,7 +1089,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15007-PI.jpg",
         "fileFormat": "jpg",
         "title": "Divergent",
@@ -1102,7 +1102,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15007-LI.jpg",
         "fileFormat": "jpg",
         "title": "Divergent",
@@ -1115,7 +1115,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15005-LI.jpg",
         "fileFormat": "jpg",
         "title": "Despicable Me 2",
@@ -1128,7 +1128,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/26/12/11/pikselss.ism",
         "fileFormat": "ism",
         "title": "District 9",
@@ -1141,7 +1141,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/26/11/33/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "District 9",
@@ -1154,7 +1154,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/11/10/piksel.mpd",
         "fileFormat": "mpd",
         "title": "District 9",
@@ -1167,7 +1167,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848763672063/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Dracula Untold",
@@ -1180,7 +1180,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848217191815/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Divergent",
@@ -1193,7 +1193,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858261386735/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Despicable Me 2",
@@ -1206,7 +1206,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555319108926/pikselss.ism",
         "fileFormat": "ism",
         "title": "Despicable Me 2",
@@ -1219,7 +1219,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825616960561/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Despicable Me 2",
@@ -1232,7 +1232,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579256133911/pikselss.ism",
         "fileFormat": "ism",
         "title": "Dracula Untold",
@@ -1245,7 +1245,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0852/UTV-BOX-15007-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Divergent",
@@ -1258,7 +1258,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1550/UTV-15005-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Despicable Me 2",
@@ -1272,7 +1272,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15005-PI.jpg",
         "fileFormat": "jpg",
         "title": "Despicable Me 2",
@@ -1285,7 +1285,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882089275595/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Dracula Untold",
@@ -1298,7 +1298,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881549181779/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Divergent",
@@ -1311,7 +1311,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579404553292/pikselss.ism",
         "fileFormat": "ism",
         "title": "Divergent",
@@ -1324,7 +1324,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0840/UTV-BOX-15043-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Dallas Buyers Club",
@@ -1338,7 +1338,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15043-PI.jpg",
         "fileFormat": "jpg",
         "title": "Dallas Buyers Club",
@@ -1352,7 +1352,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15101-PI.jpg",
         "fileFormat": "jpg",
         "title": "Despicable Me",
@@ -1366,7 +1366,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15232-PI.jpg",
         "fileFormat": "jpg",
         "title": "Date Movie",
@@ -1379,7 +1379,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0822/UTV-15101-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Despicable Me",
@@ -1392,7 +1392,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15101-LI.jpg",
         "fileFormat": "jpg",
         "title": "Despicable Me",
@@ -1405,7 +1405,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1442/UTV-15232-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Date Movie",
@@ -1418,7 +1418,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15232-LI.jpg",
         "fileFormat": "jpg",
         "title": "Date Movie",
@@ -1431,7 +1431,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1418/UTV-BOX-15044-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Dark Skies",
@@ -1445,7 +1445,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15099-PI.jpg",
         "fileFormat": "jpg",
         "title": "Date Night",
@@ -1458,7 +1458,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1054/UTV-15166-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Cloverfield",
@@ -1471,7 +1471,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/Caracol-001-LI.jpg",
         "fileFormat": "jpg",
         "title": "Ciudad Delirio",
@@ -1485,7 +1485,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/Caracol-001-PI.jpg",
         "fileFormat": "jpg",
         "title": "Ciudad Delirio",
@@ -1498,7 +1498,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0820/UTV-15099-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Date Night",
@@ -1511,7 +1511,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1549/UTV-15004-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Cloudy With A Chance Of Meatballs 2",
@@ -1524,7 +1524,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15004-LI.jpg",
         "fileFormat": "jpg",
         "title": "Cloudy With A Chance Of Meatballs 2",
@@ -1537,7 +1537,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15133-LI.jpg",
         "fileFormat": "jpg",
         "title": "Cloudy With A Chance Of Meatballs",
@@ -1551,7 +1551,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15133-PI.jpg",
         "fileFormat": "jpg",
         "title": "Cloudy With A Chance Of Meatballs",
@@ -1564,7 +1564,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0947/UTV-15133-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Cloudy With A Chance Of Meatballs",
@@ -1577,7 +1577,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173564625989200/pikselss.ism",
         "fileFormat": "ism",
         "title": "Despicable Me",
@@ -1590,7 +1590,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106867098364288/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Despicable Me",
@@ -1603,7 +1603,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2014/10/29/1552/caracolSSShowcase.ism",
         "fileFormat": "ism",
         "title": "Ciudad Delirio",
@@ -1616,7 +1616,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567326090945/pikselss.ism",
         "fileFormat": "ism",
         "title": "Cloudy With A Chance Of Meatballs",
@@ -1629,7 +1629,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173564777272730/pikselss.ism",
         "fileFormat": "ism",
         "title": "Clash of the Titans",
@@ -1642,7 +1642,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106866332994621/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Clash of the Titans",
@@ -1655,7 +1655,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870164132900/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Cloudy With A Chance Of Meatballs",
@@ -1668,7 +1668,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845884024436/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Date Movie",
@@ -1681,7 +1681,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570806693680/pikselss.ism",
         "fileFormat": "ism",
         "title": "Cloverfield",
@@ -1694,7 +1694,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873376207272/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Cloverfield",
@@ -1707,7 +1707,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840159276590/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Cloverfield",
@@ -1720,7 +1720,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555149997977/pikselss.ism",
         "fileFormat": "ism",
         "title": "Cloudy With A Chance Of Meatballs 2",
@@ -1733,7 +1733,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834458675536/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Date Night",
@@ -1746,7 +1746,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825509214392/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Cloudy With A Chance Of Meatballs 2",
@@ -1759,7 +1759,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851596469763/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Dallas Buyers Club",
@@ -1772,7 +1772,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851672173190/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Dark Skies",
@@ -1785,7 +1785,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582270881104/pikselss.ism",
         "fileFormat": "ism",
         "title": "Dark Skies",
@@ -1798,7 +1798,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884649069814/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Dark Skies",
@@ -1811,7 +1811,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15043-LI.jpg",
         "fileFormat": "jpg",
         "title": "Dallas Buyers Club",
@@ -1825,7 +1825,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15044-PI.jpg",
         "fileFormat": "jpg",
         "title": "Dark Skies",
@@ -1838,7 +1838,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15099-LI.jpg",
         "fileFormat": "jpg",
         "title": "Date Night",
@@ -1851,7 +1851,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15044-LI.jpg",
         "fileFormat": "jpg",
         "title": "Dark Skies",
@@ -1865,7 +1865,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15166-PI.jpg",
         "fileFormat": "jpg",
         "title": "Cloverfield",
@@ -1878,7 +1878,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15166-LI.jpg",
         "fileFormat": "jpg",
         "title": "Cloverfield",
@@ -1892,7 +1892,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15098-PI.jpg",
         "fileFormat": "jpg",
         "title": "Clash of the Titans",
@@ -1906,7 +1906,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15004-PI.jpg",
         "fileFormat": "jpg",
         "title": "Cloudy With A Chance Of Meatballs 2",
@@ -1919,7 +1919,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0812/UTV-15098-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Clash of the Titans",
@@ -1932,7 +1932,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15098-LI.jpg",
         "fileFormat": "jpg",
         "title": "Clash of the Titans",
@@ -1945,7 +1945,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834542991976/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Despicable Me",
@@ -1958,7 +1958,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837161376564/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Cloudy With A Chance Of Meatballs",
@@ -1971,7 +1971,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106866893741885/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Date Night",
@@ -1984,7 +1984,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563901364957/pikselss.ism",
         "fileFormat": "ism",
         "title": "Date Night",
@@ -1997,7 +1997,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834357154126/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Clash of the Titans",
@@ -2010,7 +2010,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577046923642/pikselss.ism",
         "fileFormat": "ism",
         "title": "Date Movie",
@@ -2023,7 +2023,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879104423232/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Date Movie",
@@ -2036,7 +2036,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858170840324/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Cloudy With A Chance Of Meatballs 2",
@@ -2049,7 +2049,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884568134790/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Dallas Buyers Club",
@@ -2062,7 +2062,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582196865017/pikselss.ism",
         "fileFormat": "ism",
         "title": "Dallas Buyers Club",

--- a/test/fixtures/media-items-3.json
+++ b/test/fixtures/media-items-3.json
@@ -13,25 +13,25 @@
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15037%7C%7Csa-team%3AUTV-BOX-15030%7C%7Csa-team%3AUTV-15070%7C%7Csa-team%3AUTV-15169&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15037%7C%7Csa-team%3AUTV-BOX-15030%7C%7Csa-team%3AUTV-15070%7C%7Csa-team%3AUTV-15169&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15037%7C%7Csa-team%3AUTV-BOX-15030%7C%7Csa-team%3AUTV-15070%7C%7Csa-team%3AUTV-15169"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15037%7C%7Csa-team%3AUTV-BOX-15030%7C%7Csa-team%3AUTV-15070%7C%7Csa-team%3AUTV-15169&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15037%7C%7Csa-team%3AUTV-BOX-15030%7C%7Csa-team%3AUTV-15070%7C%7Csa-team%3AUTV-15169&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15037%7C%7Csa-team%3AUTV-BOX-15030%7C%7Csa-team%3AUTV-15070%7C%7Csa-team%3AUTV-15169"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15200%7C%7Csa-team%3AUTV-15037%7C%7Csa-team%3AUTV-15102%7C%7Csa-team%3AUTV-BOX-15009%7C%7Csa-team%3AUTV-15201%7C%7Csa-team%3AUTV-BOX-15027%7C%7Csa-team%3AUTV-15135%7C%7Csa-team%3AUTV-15202%7C%7Csa-team%3AUTV-15136%7C%7Csa-team%3AUTV-15007&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15200%7C%7Csa-team%3AUTV-15037%7C%7Csa-team%3AUTV-15102%7C%7Csa-team%3AUTV-BOX-15009%7C%7Csa-team%3AUTV-15201%7C%7Csa-team%3AUTV-BOX-15027%7C%7Csa-team%3AUTV-15135%7C%7Csa-team%3AUTV-15202%7C%7Csa-team%3AUTV-15136%7C%7Csa-team%3AUTV-15007&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15200%7C%7Csa-team%3AUTV-15037%7C%7Csa-team%3AUTV-15102%7C%7Csa-team%3AUTV-BOX-15009%7C%7Csa-team%3AUTV-15201%7C%7Csa-team%3AUTV-BOX-15027%7C%7Csa-team%3AUTV-15135%7C%7Csa-team%3AUTV-15202%7C%7Csa-team%3AUTV-15136%7C%7Csa-team%3AUTV-15007"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15200%7C%7Csa-team%3AUTV-15037%7C%7Csa-team%3AUTV-15102%7C%7Csa-team%3AUTV-BOX-15009%7C%7Csa-team%3AUTV-15201%7C%7Csa-team%3AUTV-BOX-15027%7C%7Csa-team%3AUTV-15135%7C%7Csa-team%3AUTV-15202%7C%7Csa-team%3AUTV-15136%7C%7Csa-team%3AUTV-15007&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15200%7C%7Csa-team%3AUTV-15037%7C%7Csa-team%3AUTV-15102%7C%7Csa-team%3AUTV-BOX-15009%7C%7Csa-team%3AUTV-15201%7C%7Csa-team%3AUTV-BOX-15027%7C%7Csa-team%3AUTV-15135%7C%7Csa-team%3AUTV-15202%7C%7Csa-team%3AUTV-15136%7C%7Csa-team%3AUTV-15007&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15200%7C%7Csa-team%3AUTV-15037%7C%7Csa-team%3AUTV-15102%7C%7Csa-team%3AUTV-BOX-15009%7C%7Csa-team%3AUTV-15201%7C%7Csa-team%3AUTV-BOX-15027%7C%7Csa-team%3AUTV-15135%7C%7Csa-team%3AUTV-15202%7C%7Csa-team%3AUTV-15136%7C%7Csa-team%3AUTV-15007"
         },
         {
           "totalCount": 58,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15153%7C%7Csa-team%3AUTV-15167%7C%7Csa-team%3AUTV-15168%7C%7Csa-team%3AUTV-15203%7C%7Csa-team%3AUTV-15008%7C%7Csa-team%3AUTV-15233%7C%7Csa-team%3AUTV-BOX-15024%7C%7Csa-team%3AUTV-15068%7C%7Csa-team%3AUTV-15204%7C%7Csa-team%3AUTV-15069&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15153%7C%7Csa-team%3AUTV-15167%7C%7Csa-team%3AUTV-15168%7C%7Csa-team%3AUTV-15203%7C%7Csa-team%3AUTV-15008%7C%7Csa-team%3AUTV-15233%7C%7Csa-team%3AUTV-BOX-15024%7C%7Csa-team%3AUTV-15068%7C%7Csa-team%3AUTV-15204%7C%7Csa-team%3AUTV-15069&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15153%7C%7Csa-team%3AUTV-15167%7C%7Csa-team%3AUTV-15168%7C%7Csa-team%3AUTV-15203%7C%7Csa-team%3AUTV-15008%7C%7Csa-team%3AUTV-15233%7C%7Csa-team%3AUTV-BOX-15024%7C%7Csa-team%3AUTV-15068%7C%7Csa-team%3AUTV-15204%7C%7Csa-team%3AUTV-15069"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15153%7C%7Csa-team%3AUTV-15167%7C%7Csa-team%3AUTV-15168%7C%7Csa-team%3AUTV-15203%7C%7Csa-team%3AUTV-15008%7C%7Csa-team%3AUTV-15233%7C%7Csa-team%3AUTV-BOX-15024%7C%7Csa-team%3AUTV-15068%7C%7Csa-team%3AUTV-15204%7C%7Csa-team%3AUTV-15069&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15153%7C%7Csa-team%3AUTV-15167%7C%7Csa-team%3AUTV-15168%7C%7Csa-team%3AUTV-15203%7C%7Csa-team%3AUTV-15008%7C%7Csa-team%3AUTV-15233%7C%7Csa-team%3AUTV-BOX-15024%7C%7Csa-team%3AUTV-15068%7C%7Csa-team%3AUTV-15204%7C%7Csa-team%3AUTV-15069&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15153%7C%7Csa-team%3AUTV-15167%7C%7Csa-team%3AUTV-15168%7C%7Csa-team%3AUTV-15203%7C%7Csa-team%3AUTV-15008%7C%7Csa-team%3AUTV-15233%7C%7Csa-team%3AUTV-BOX-15024%7C%7Csa-team%3AUTV-15068%7C%7Csa-team%3AUTV-15204%7C%7Csa-team%3AUTV-15069"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883519813480/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Guardians Of The Galaxy",
@@ -324,7 +324,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173581374492101/pikselss.ism",
         "fileFormat": "ism",
         "title": "Guardians Of The Galaxy",
@@ -337,7 +337,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1358/UTV-BOX-15030-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Guardians Of The Galaxy",
@@ -351,7 +351,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15030-PI.jpg",
         "fileFormat": "jpg",
         "title": "Guardians Of The Galaxy",
@@ -364,7 +364,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15030-LI.jpg",
         "fileFormat": "jpg",
         "title": "Guardians Of The Galaxy",
@@ -378,7 +378,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15037-PI.jpg",
         "fileFormat": "jpg",
         "title": "Grown Ups 2",
@@ -391,7 +391,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15037-LI.jpg",
         "fileFormat": "jpg",
         "title": "Grown Ups 2",
@@ -404,7 +404,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15070-LI.jpg",
         "fileFormat": "jpg",
         "title": "Gulliver's Travels",
@@ -418,7 +418,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15070-PI.jpg",
         "fileFormat": "jpg",
         "title": "Gulliver's Travels",
@@ -431,7 +431,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0726/UTV-15070-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Gulliver's Travels",
@@ -445,7 +445,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15169-PI.jpg",
         "fileFormat": "jpg",
         "title": "Hancock",
@@ -458,7 +458,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1100/UTV-15169-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Hancock",
@@ -471,7 +471,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873618707905/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Hancock",
@@ -484,7 +484,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570347911341/pikselss.ism",
         "fileFormat": "ism",
         "title": "Hancock",
@@ -497,7 +497,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864057623491/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Gulliver's Travels",
@@ -510,7 +510,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851078676906/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Grown Ups 2",
@@ -523,7 +523,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173581663362631/pikselss.ism",
         "fileFormat": "ism",
         "title": "Grown Ups 2",
@@ -536,7 +536,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0826/UTV-BOX-15037-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Grown Ups 2",
@@ -549,7 +549,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15169-LI.jpg",
         "fileFormat": "jpg",
         "title": "Hancock",
@@ -562,7 +562,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561195570987/pikselss.ism",
         "fileFormat": "ism",
         "title": "Gulliver's Travels",
@@ -575,7 +575,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831759209833/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Gulliver's Travels",
@@ -588,7 +588,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840524616131/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Hancock",
@@ -601,7 +601,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850541060349/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Guardians Of The Galaxy",
@@ -614,7 +614,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884041158586/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Grown Ups 2",
@@ -628,7 +628,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15201-PI.jpg",
         "fileFormat": "jpg",
         "title": "Enchanted",
@@ -641,7 +641,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0823/UTV-BOX-15027-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Ender's Game: The IMAX Experience",
@@ -654,7 +654,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15027-LI.jpg",
         "fileFormat": "jpg",
         "title": "Ender's Game: The IMAX Experience",
@@ -668,7 +668,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15200-PI.jpg",
         "fileFormat": "jpg",
         "title": "Dreamgirls",
@@ -682,7 +682,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15009-PI.jpg",
         "fileFormat": "jpg",
         "title": "Edge Of Tomorrow",
@@ -695,7 +695,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1327/UTV-BOX-15009-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Edge Of Tomorrow",
@@ -708,7 +708,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15037-LI.jpg",
         "fileFormat": "jpg",
         "title": "Dredd",
@@ -722,7 +722,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15037-PI.jpg",
         "fileFormat": "jpg",
         "title": "Dredd",
@@ -735,7 +735,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0653/UTV-15037-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Dredd",
@@ -748,7 +748,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1116/UTV-15200-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Dreamgirls",
@@ -761,7 +761,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15200-LI.jpg",
         "fileFormat": "jpg",
         "title": "Dreamgirls",
@@ -774,7 +774,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15009-LI.jpg",
         "fileFormat": "jpg",
         "title": "Edge Of Tomorrow",
@@ -787,7 +787,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15202-LI.jpg",
         "fileFormat": "jpg",
         "title": "Fantastic 4: Rise Of The Silver Surfer",
@@ -800,7 +800,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1359/UTV-15202-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Fantastic 4: Rise Of The Silver Surfer",
@@ -814,7 +814,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15202-PI.jpg",
         "fileFormat": "jpg",
         "title": "Fantastic 4: Rise Of The Silver Surfer",
@@ -827,7 +827,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15102-LI.jpg",
         "fileFormat": "jpg",
         "title": "Due Date",
@@ -840,7 +840,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0824/UTV-15102-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Due Date",
@@ -853,7 +853,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15136-LI.jpg",
         "fileFormat": "jpg",
         "title": "Fast & Furious",
@@ -866,7 +866,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1552/UTV-15007-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Fast & Furious 6",
@@ -879,7 +879,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0950/UTV-15135-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Fame",
@@ -892,7 +892,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15007-LI.jpg",
         "fileFormat": "jpg",
         "title": "Fast & Furious 6",
@@ -906,7 +906,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15135-PI.jpg",
         "fileFormat": "jpg",
         "title": "Fame",
@@ -920,7 +920,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15007-PI.jpg",
         "fileFormat": "jpg",
         "title": "Fast & Furious 6",
@@ -933,7 +933,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106867180949427/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Due Date",
@@ -946,7 +946,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567538102057/pikselss.ism",
         "fileFormat": "ism",
         "title": "Fame",
@@ -959,7 +959,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828899945683/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Dredd",
@@ -972,7 +972,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861345030197/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Dredd",
@@ -985,7 +985,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558106291511/pikselss.ism",
         "fileFormat": "ism",
         "title": "Dredd",
@@ -998,7 +998,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875891945205/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Dreamgirls",
@@ -1011,7 +1011,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573805657738/pikselss.ism",
         "fileFormat": "ism",
         "title": "Enchanted",
@@ -1024,7 +1024,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843050294725/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Dreamgirls",
@@ -1037,7 +1037,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843137471266/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Enchanted",
@@ -1050,7 +1050,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843229251257/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Fantastic 4: Rise Of The Silver Surfer",
@@ -1063,7 +1063,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106876066829376/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Fantastic 4: Rise Of The Silver Surfer",
@@ -1076,7 +1076,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837315076339/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Fast & Furious",
@@ -1089,7 +1089,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875979000753/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Enchanted",
@@ -1102,7 +1102,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870348759460/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Fast & Furious",
@@ -1115,7 +1115,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881848141542/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Edge Of Tomorrow",
@@ -1128,7 +1128,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579735853560/pikselss.ism",
         "fileFormat": "ism",
         "title": "Edge Of Tomorrow",
@@ -1141,7 +1141,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848508282346/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Edge Of Tomorrow",
@@ -1154,7 +1154,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573642052924/pikselss.ism",
         "fileFormat": "ism",
         "title": "Dreamgirls",
@@ -1167,7 +1167,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825772053807/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Fast & Furious 6",
@@ -1180,7 +1180,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858336277631/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Fast & Furious 6",
@@ -1193,7 +1193,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850311887181/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Ender's Game: The IMAX Experience",
@@ -1206,7 +1206,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580758690069/pikselss.ism",
         "fileFormat": "ism",
         "title": "Ender's Game: The IMAX Experience",
@@ -1219,7 +1219,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15201-LI.jpg",
         "fileFormat": "jpg",
         "title": "Enchanted",
@@ -1233,7 +1233,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15027-PI.jpg",
         "fileFormat": "jpg",
         "title": "Ender's Game: The IMAX Experience",
@@ -1247,7 +1247,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15102-PI.jpg",
         "fileFormat": "jpg",
         "title": "Due Date",
@@ -1260,7 +1260,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15135-LI.jpg",
         "fileFormat": "jpg",
         "title": "Fame",
@@ -1273,7 +1273,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0955/UTV-15136-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Fast & Furious",
@@ -1287,7 +1287,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15136-PI.jpg",
         "fileFormat": "jpg",
         "title": "Fast & Furious",
@@ -1300,7 +1300,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173564700766072/pikselss.ism",
         "fileFormat": "ism",
         "title": "Due Date",
@@ -1313,7 +1313,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834624836693/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Due Date",
@@ -1326,7 +1326,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837238624495/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Fame",
@@ -1339,7 +1339,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870244777330/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Fame",
@@ -1352,7 +1352,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567773599491/pikselss.ism",
         "fileFormat": "ism",
         "title": "Fast & Furious",
@@ -1365,7 +1365,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572923205941/pikselss.ism",
         "fileFormat": "ism",
         "title": "Fantastic 4: Rise Of The Silver Surfer",
@@ -1378,7 +1378,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555394214032/pikselss.ism",
         "fileFormat": "ism",
         "title": "Fast & Furious 6",
@@ -1391,7 +1391,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883276442585/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Ender's Game: The IMAX Experience",
@@ -1404,7 +1404,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15204-LI.jpg",
         "fileFormat": "jpg",
         "title": "Good Luck Chuck",
@@ -1417,7 +1417,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1352/UTV-BOX-15024-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "G.I. Joe: Retaliation",
@@ -1431,7 +1431,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15024-PI.jpg",
         "fileFormat": "jpg",
         "title": "G.I. Joe: Retaliation",
@@ -1444,7 +1444,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15024-LI.jpg",
         "fileFormat": "jpg",
         "title": "G.I. Joe: Retaliation",
@@ -1458,7 +1458,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15204-PI.jpg",
         "fileFormat": "jpg",
         "title": "Good Luck Chuck",
@@ -1471,7 +1471,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0722/UTV-15068-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Gnomeo and Juliet",
@@ -1485,7 +1485,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15068-PI.jpg",
         "fileFormat": "jpg",
         "title": "Gnomeo and Juliet",
@@ -1499,7 +1499,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15069-PI.jpg",
         "fileFormat": "jpg",
         "title": "Green Lantern",
@@ -1512,7 +1512,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15153-LI.jpg",
         "fileFormat": "jpg",
         "title": "Final Destination",
@@ -1525,7 +1525,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1405/UTV-15203-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Fred Claus",
@@ -1538,7 +1538,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15203-LI.jpg",
         "fileFormat": "jpg",
         "title": "Fred Claus",
@@ -1552,7 +1552,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15203-PI.jpg",
         "fileFormat": "jpg",
         "title": "Fred Claus",
@@ -1565,7 +1565,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1554/UTV-15008-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Frozen",
@@ -1579,7 +1579,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15008-PI.jpg",
         "fileFormat": "jpg",
         "title": "Frozen",
@@ -1592,7 +1592,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15167-LI.jpg",
         "fileFormat": "jpg",
         "title": "Forgetting Sarah Marshall",
@@ -1605,7 +1605,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15168-LI.jpg",
         "fileFormat": "jpg",
         "title": "Four Christmases",
@@ -1618,7 +1618,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1058/UTV-15168-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Four Christmases",
@@ -1632,7 +1632,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15233-PI.jpg",
         "fileFormat": "jpg",
         "title": "Fun With Dick And Jane",
@@ -1645,7 +1645,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1444/UTV-15233-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Fun With Dick And Jane",
@@ -1658,7 +1658,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15233-LI.jpg",
         "fileFormat": "jpg",
         "title": "Fun With Dick And Jane",
@@ -1671,7 +1671,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573238767278/pikselss.ism",
         "fileFormat": "ism",
         "title": "Good Luck Chuck",
@@ -1684,7 +1684,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106876217571671/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Good Luck Chuck",
@@ -1697,7 +1697,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840408859520/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Four Christmases",
@@ -1710,7 +1710,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570095796580/pikselss.ism",
         "fileFormat": "ism",
         "title": "Four Christmases",
@@ -1723,7 +1723,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873539822254/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Four Christmases",
@@ -1736,7 +1736,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173560732030937/pikselss.ism",
         "fileFormat": "ism",
         "title": "Gnomeo and Juliet",
@@ -1749,7 +1749,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863827538397/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Gnomeo and Juliet",
@@ -1762,7 +1762,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831390672975/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Gnomeo and Juliet",
@@ -1775,7 +1775,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873464353889/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Forgetting Sarah Marshall",
@@ -1788,7 +1788,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825926781641/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Frozen",
@@ -1801,7 +1801,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561114085793/pikselss.ism",
         "fileFormat": "ism",
         "title": "Green Lantern",
@@ -1814,7 +1814,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840263301483/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Forgetting Sarah Marshall",
@@ -1827,7 +1827,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570014749125/pikselss.ism",
         "fileFormat": "ism",
         "title": "Forgetting Sarah Marshall",
@@ -1840,7 +1840,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863910450697/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Green Lantern",
@@ -1853,7 +1853,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879190834544/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Fun With Dick And Jane",
@@ -1866,7 +1866,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843311991275/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Fred Claus",
@@ -1879,7 +1879,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106876142877834/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Fred Claus",
@@ -1892,7 +1892,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573081469199/pikselss.ism",
         "fileFormat": "ism",
         "title": "Fred Claus",
@@ -1905,7 +1905,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577319814419/pikselss.ism",
         "fileFormat": "ism",
         "title": "Fun With Dick And Jane",
@@ -1918,7 +1918,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858410984675/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Frozen",
@@ -1931,7 +1931,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883025742444/piksel.mpd",
         "fileFormat": "mpd",
         "title": "G.I. Joe: Retaliation",
@@ -1944,7 +1944,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580309693889/pikselss.ism",
         "fileFormat": "ism",
         "title": "G.I. Joe: Retaliation",
@@ -1957,7 +1957,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1406/UTV-15204-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Good Luck Chuck",
@@ -1970,7 +1970,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15068-LI.jpg",
         "fileFormat": "jpg",
         "title": "Gnomeo and Juliet",
@@ -1984,7 +1984,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15167-PI.jpg",
         "fileFormat": "jpg",
         "title": "Forgetting Sarah Marshall",
@@ -1997,7 +1997,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1056/UTV-15167-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Forgetting Sarah Marshall",
@@ -2010,7 +2010,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15069-LI.jpg",
         "fileFormat": "jpg",
         "title": "Green Lantern",
@@ -2024,7 +2024,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15153-PI.jpg",
         "fileFormat": "jpg",
         "title": "Final Destination",
@@ -2038,7 +2038,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15168-PI.jpg",
         "fileFormat": "jpg",
         "title": "Four Christmases",
@@ -2051,7 +2051,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15008-LI.jpg",
         "fileFormat": "jpg",
         "title": "Frozen",
@@ -2064,7 +2064,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843393347511/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Good Luck Chuck",
@@ -2077,7 +2077,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831660223958/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Green Lantern",
@@ -2090,7 +2090,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839131175222/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Final Destination",
@@ -2103,7 +2103,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173568918276584/pikselss.ism",
         "fileFormat": "ism",
         "title": "Final Destination",
@@ -2116,7 +2116,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872328179880/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Final Destination",
@@ -2129,7 +2129,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555834230821/pikselss.ism",
         "fileFormat": "ism",
         "title": "Frozen",
@@ -2142,7 +2142,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121845963305364/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Fun With Dick And Jane",
@@ -2155,7 +2155,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849947190634/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "G.I. Joe: Retaliation",

--- a/test/fixtures/media-items-4.json
+++ b/test/fixtures/media-items-4.json
@@ -13,25 +13,25 @@
           "totalCount": 60,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15206%7C%7Csa-team%3AUTV-15173%7C%7Csa-team%3AUTV-BOX-15014%7C%7Csa-team%3AUTV-15174%7C%7Csa-team%3AUTV-15235%7C%7Csa-team%3AUTV-15138%7C%7Csa-team%3AUTV-15073%7C%7Csa-team%3AUTV-15106%7C%7Csa-team%3AUTV-15175%7C%7Csa-team%3AUTV-15139&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15206%7C%7Csa-team%3AUTV-15173%7C%7Csa-team%3AUTV-BOX-15014%7C%7Csa-team%3AUTV-15174%7C%7Csa-team%3AUTV-15235%7C%7Csa-team%3AUTV-15138%7C%7Csa-team%3AUTV-15073%7C%7Csa-team%3AUTV-15106%7C%7Csa-team%3AUTV-15175%7C%7Csa-team%3AUTV-15139&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15206%7C%7Csa-team%3AUTV-15173%7C%7Csa-team%3AUTV-BOX-15014%7C%7Csa-team%3AUTV-15174%7C%7Csa-team%3AUTV-15235%7C%7Csa-team%3AUTV-15138%7C%7Csa-team%3AUTV-15073%7C%7Csa-team%3AUTV-15106%7C%7Csa-team%3AUTV-15175%7C%7Csa-team%3AUTV-15139"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15206%7C%7Csa-team%3AUTV-15173%7C%7Csa-team%3AUTV-BOX-15014%7C%7Csa-team%3AUTV-15174%7C%7Csa-team%3AUTV-15235%7C%7Csa-team%3AUTV-15138%7C%7Csa-team%3AUTV-15073%7C%7Csa-team%3AUTV-15106%7C%7Csa-team%3AUTV-15175%7C%7Csa-team%3AUTV-15139&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15206%7C%7Csa-team%3AUTV-15173%7C%7Csa-team%3AUTV-BOX-15014%7C%7Csa-team%3AUTV-15174%7C%7Csa-team%3AUTV-15235%7C%7Csa-team%3AUTV-15138%7C%7Csa-team%3AUTV-15073%7C%7Csa-team%3AUTV-15106%7C%7Csa-team%3AUTV-15175%7C%7Csa-team%3AUTV-15139&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15206%7C%7Csa-team%3AUTV-15173%7C%7Csa-team%3AUTV-BOX-15014%7C%7Csa-team%3AUTV-15174%7C%7Csa-team%3AUTV-15235%7C%7Csa-team%3AUTV-15138%7C%7Csa-team%3AUTV-15073%7C%7Csa-team%3AUTV-15106%7C%7Csa-team%3AUTV-15175%7C%7Csa-team%3AUTV-15139"
         },
         {
           "totalCount": 58,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15010%7C%7Csa-team%3AUTV-15234%7C%7Csa-team%3AUTV-15105%7C%7Csa-team%3AUTV-15071%7C%7Csa-team%3AUTV-15137%7C%7Csa-team%3AUTV-15205%7C%7Csa-team%3AUTV-BOX-15015%7C%7Csa-team%3AUTV-15170%7C%7Csa-team%3AUTV-15171%7C%7Csa-team%3AUTV-15072&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15010%7C%7Csa-team%3AUTV-15234%7C%7Csa-team%3AUTV-15105%7C%7Csa-team%3AUTV-15071%7C%7Csa-team%3AUTV-15137%7C%7Csa-team%3AUTV-15205%7C%7Csa-team%3AUTV-BOX-15015%7C%7Csa-team%3AUTV-15170%7C%7Csa-team%3AUTV-15171%7C%7Csa-team%3AUTV-15072&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15010%7C%7Csa-team%3AUTV-15234%7C%7Csa-team%3AUTV-15105%7C%7Csa-team%3AUTV-15071%7C%7Csa-team%3AUTV-15137%7C%7Csa-team%3AUTV-15205%7C%7Csa-team%3AUTV-BOX-15015%7C%7Csa-team%3AUTV-15170%7C%7Csa-team%3AUTV-15171%7C%7Csa-team%3AUTV-15072"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15010%7C%7Csa-team%3AUTV-15234%7C%7Csa-team%3AUTV-15105%7C%7Csa-team%3AUTV-15071%7C%7Csa-team%3AUTV-15137%7C%7Csa-team%3AUTV-15205%7C%7Csa-team%3AUTV-BOX-15015%7C%7Csa-team%3AUTV-15170%7C%7Csa-team%3AUTV-15171%7C%7Csa-team%3AUTV-15072&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15010%7C%7Csa-team%3AUTV-15234%7C%7Csa-team%3AUTV-15105%7C%7Csa-team%3AUTV-15071%7C%7Csa-team%3AUTV-15137%7C%7Csa-team%3AUTV-15205%7C%7Csa-team%3AUTV-BOX-15015%7C%7Csa-team%3AUTV-15170%7C%7Csa-team%3AUTV-15171%7C%7Csa-team%3AUTV-15072&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15010%7C%7Csa-team%3AUTV-15234%7C%7Csa-team%3AUTV-15105%7C%7Csa-team%3AUTV-15071%7C%7Csa-team%3AUTV-15137%7C%7Csa-team%3AUTV-15205%7C%7Csa-team%3AUTV-BOX-15015%7C%7Csa-team%3AUTV-15170%7C%7Csa-team%3AUTV-15171%7C%7Csa-team%3AUTV-15072"
         },
         {
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15011%7C%7Csa-team%3AUTV-15176%7C%7Csa-team%3AUTV-15107%7C%7Csa-team%3AUTV-15012&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15011%7C%7Csa-team%3AUTV-15176%7C%7Csa-team%3AUTV-15107%7C%7Csa-team%3AUTV-15012&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15011%7C%7Csa-team%3AUTV-15176%7C%7Csa-team%3AUTV-15107%7C%7Csa-team%3AUTV-15012"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15011%7C%7Csa-team%3AUTV-15176%7C%7Csa-team%3AUTV-15107%7C%7Csa-team%3AUTV-15012&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15011%7C%7Csa-team%3AUTV-15176%7C%7Csa-team%3AUTV-15107%7C%7Csa-team%3AUTV-15012&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15011%7C%7Csa-team%3AUTV-15176%7C%7Csa-team%3AUTV-15107%7C%7Csa-team%3AUTV-15012"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15235-LI.jpg",
         "fileFormat": "jpg",
         "title": "Ice Age The Meltdown",
@@ -324,7 +324,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1409/UTV-15206-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Hot Fuzz",
@@ -338,7 +338,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15206-PI.jpg",
         "fileFormat": "jpg",
         "title": "Hot Fuzz",
@@ -351,7 +351,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1446/UTV-15235-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Ice Age The Meltdown",
@@ -365,7 +365,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15235-PI.jpg",
         "fileFormat": "jpg",
         "title": "Ice Age The Meltdown",
@@ -378,7 +378,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15175-LI.jpg",
         "fileFormat": "jpg",
         "title": "Indiana Jones And The Kingdom Of The Crystal Skull",
@@ -391,7 +391,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15106-LI.jpg",
         "fileFormat": "jpg",
         "title": "Inception",
@@ -404,7 +404,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0828/UTV-15106-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Inception",
@@ -417,7 +417,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1302/UTV-15175-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Indiana Jones And The Kingdom Of The Crystal Skull",
@@ -431,7 +431,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15106-PI.jpg",
         "fileFormat": "jpg",
         "title": "Inception",
@@ -444,7 +444,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1336/UTV-BOX-15014-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "How to Train Your Dragon 2",
@@ -457,7 +457,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15014-LI.jpg",
         "fileFormat": "jpg",
         "title": "How to Train Your Dragon 2",
@@ -471,7 +471,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15014-PI.jpg",
         "fileFormat": "jpg",
         "title": "How to Train Your Dragon 2",
@@ -484,7 +484,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0948/UTV-15073-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Immortals",
@@ -498,7 +498,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15073-PI.jpg",
         "fileFormat": "jpg",
         "title": "Immortals",
@@ -512,7 +512,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15138-PI.jpg",
         "fileFormat": "jpg",
         "title": "Ice Age: Dawn Of The Dinosaurs",
@@ -525,7 +525,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15073-LI.jpg",
         "fileFormat": "jpg",
         "title": "Immortals",
@@ -538,7 +538,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1258/UTV-15174-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "I Am Legend",
@@ -551,7 +551,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15174-LI.jpg",
         "fileFormat": "jpg",
         "title": "I Am Legend",
@@ -565,7 +565,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15174-PI.jpg",
         "fileFormat": "jpg",
         "title": "I Am Legend",
@@ -578,7 +578,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1007/UTV-15139-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Inglourious Basterds",
@@ -591,7 +591,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15139-LI.jpg",
         "fileFormat": "jpg",
         "title": "Inglourious Basterds",
@@ -604,7 +604,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15138-LI.jpg",
         "fileFormat": "jpg",
         "title": "Ice Age: Dawn Of The Dinosaurs",
@@ -617,7 +617,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1256/UTV-15173-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "How To Lose Friends & Alienate People",
@@ -630,7 +630,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1004/UTV-15138-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Ice Age: Dawn Of The Dinosaurs",
@@ -643,7 +643,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15173-LI.jpg",
         "fileFormat": "jpg",
         "title": "How To Lose Friends & Alienate People",
@@ -657,7 +657,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15173-PI.jpg",
         "fileFormat": "jpg",
         "title": "How To Lose Friends & Alienate People",
@@ -670,7 +670,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573728585886/pikselss.ism",
         "fileFormat": "ism",
         "title": "Hot Fuzz",
@@ -683,7 +683,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843550569065/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Hot Fuzz",
@@ -696,7 +696,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106876817442984/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Hot Fuzz",
@@ -709,7 +709,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834796937224/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Inception",
@@ -722,7 +722,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106867482329131/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Inception",
@@ -735,7 +735,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837667452022/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Ice Age: Dawn Of The Dinosaurs",
@@ -748,7 +748,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870667889687/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Ice Age: Dawn Of The Dinosaurs",
@@ -761,7 +761,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837753059704/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Inglourious Basterds",
@@ -774,7 +774,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565049765308/pikselss.ism",
         "fileFormat": "ism",
         "title": "Inception",
@@ -787,7 +787,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874049469357/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Indiana Jones And The Kingdom Of The Crystal Skull",
@@ -800,7 +800,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571430321614/pikselss.ism",
         "fileFormat": "ism",
         "title": "Indiana Jones And The Kingdom Of The Crystal Skull",
@@ -813,7 +813,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567140619346/pikselss.ism",
         "fileFormat": "ism",
         "title": "Ice Age: Dawn Of The Dinosaurs",
@@ -826,7 +826,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870743128687/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Inglourious Basterds",
@@ -839,7 +839,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873875332174/piksel.mpd",
         "fileFormat": "mpd",
         "title": "How To Lose Friends & Alienate People",
@@ -852,7 +852,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561969857456/pikselss.ism",
         "fileFormat": "ism",
         "title": "Immortals",
@@ -865,7 +865,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873963505502/piksel.mpd",
         "fileFormat": "mpd",
         "title": "I Am Legend",
@@ -878,7 +878,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846241684273/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Ice Age The Meltdown",
@@ -891,7 +891,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121832190809771/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Immortals",
@@ -904,7 +904,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864436787012/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Immortals",
@@ -917,7 +917,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567213631961/pikselss.ism",
         "fileFormat": "ism",
         "title": "Inglourious Basterds",
@@ -930,7 +930,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879367108342/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Ice Age The Meltdown",
@@ -943,7 +943,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571135998063/pikselss.ism",
         "fileFormat": "ism",
         "title": "I Am Legend",
@@ -956,7 +956,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15206-LI.jpg",
         "fileFormat": "jpg",
         "title": "Hot Fuzz",
@@ -970,7 +970,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15175-PI.jpg",
         "fileFormat": "jpg",
         "title": "Indiana Jones And The Kingdom Of The Crystal Skull",
@@ -984,7 +984,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15139-PI.jpg",
         "fileFormat": "jpg",
         "title": "Inglourious Basterds",
@@ -997,7 +997,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840890229524/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "How To Lose Friends & Alienate People",
@@ -1010,7 +1010,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570892948968/pikselss.ism",
         "fileFormat": "ism",
         "title": "How To Lose Friends & Alienate People",
@@ -1023,7 +1023,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577576153915/pikselss.ism",
         "fileFormat": "ism",
         "title": "Ice Age The Meltdown",
@@ -1036,7 +1036,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841106157194/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Indiana Jones And The Kingdom Of The Crystal Skull",
@@ -1049,7 +1049,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840993720407/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "I Am Legend",
@@ -1062,7 +1062,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848969810519/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "How to Train Your Dragon 2",
@@ -1075,7 +1075,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882175721354/piksel.mpd",
         "fileFormat": "mpd",
         "title": "How to Train Your Dragon 2",
@@ -1088,7 +1088,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579331063919/pikselss.ism",
         "fileFormat": "ism",
         "title": "How to Train Your Dragon 2",
@@ -1101,7 +1101,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15071-LI.jpg",
         "fileFormat": "jpg",
         "title": "Harry Potter And The Deathly Hallows, Part 2",
@@ -1114,7 +1114,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0727/UTV-15071-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Harry Potter And The Deathly Hallows, Part 2",
@@ -1128,7 +1128,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15071-PI.jpg",
         "fileFormat": "jpg",
         "title": "Harry Potter And The Deathly Hallows, Part 2",
@@ -1141,7 +1141,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15015-LI.jpg",
         "fileFormat": "jpg",
         "title": "Hector and the Search for Happiness",
@@ -1155,7 +1155,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15015-PI.jpg",
         "fileFormat": "jpg",
         "title": "Hector and the Search for Happiness",
@@ -1168,7 +1168,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1445/UTV-15234-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Happy Feet",
@@ -1181,7 +1181,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1559/UTV-15010-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Hansel and Gretel: Witch Hunters",
@@ -1194,7 +1194,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15010-LI.jpg",
         "fileFormat": "jpg",
         "title": "Hansel and Gretel: Witch Hunters",
@@ -1208,7 +1208,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15105-PI.jpg",
         "fileFormat": "jpg",
         "title": "Harry Potter And The Deathly Hallows, Part 1",
@@ -1222,7 +1222,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15170-PI.jpg",
         "fileFormat": "jpg",
         "title": "Hellboy II: The Golden Army",
@@ -1235,7 +1235,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15171-LI.jpg",
         "fileFormat": "jpg",
         "title": "High School Musical 3: Senior Year",
@@ -1249,7 +1249,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15205-PI.jpg",
         "fileFormat": "jpg",
         "title": "Harry Potter and the Order of the Phoenix",
@@ -1263,7 +1263,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15072-PI.jpg",
         "fileFormat": "jpg",
         "title": "Hop",
@@ -1276,7 +1276,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15137-LI.jpg",
         "fileFormat": "jpg",
         "title": "Harry Potter And The Half Blood Prince",
@@ -1289,7 +1289,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1000/UTV-15137-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Harry Potter And The Half Blood Prince",
@@ -1302,7 +1302,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15170-LI.jpg",
         "fileFormat": "jpg",
         "title": "Hellboy II: The Golden Army",
@@ -1315,7 +1315,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15072-LI.jpg",
         "fileFormat": "jpg",
         "title": "Hop",
@@ -1329,7 +1329,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15171-PI.jpg",
         "fileFormat": "jpg",
         "title": "High School Musical 3: Senior Year",
@@ -1342,7 +1342,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849049734629/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Hector and the Search for Happiness",
@@ -1355,7 +1355,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882250633977/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Hector and the Search for Happiness",
@@ -1368,7 +1368,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579586531932/pikselss.ism",
         "fileFormat": "ism",
         "title": "Hector and the Search for Happiness",
@@ -1381,7 +1381,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864279398360/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Harry Potter And The Deathly Hallows, Part 2",
@@ -1394,7 +1394,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106867278682633/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Harry Potter And The Deathly Hallows, Part 1",
@@ -1407,7 +1407,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834718831720/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Harry Potter And The Deathly Hallows, Part 1",
@@ -1420,7 +1420,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577482886109/pikselss.ism",
         "fileFormat": "ism",
         "title": "Happy Feet",
@@ -1433,7 +1433,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846041929268/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Happy Feet",
@@ -1446,7 +1446,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840780925088/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "High School Musical 3: Senior Year",
@@ -1459,7 +1459,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573439705488/pikselss.ism",
         "fileFormat": "ism",
         "title": "Harry Potter and the Order of the Phoenix",
@@ -1472,7 +1472,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873718443068/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Hellboy II: The Golden Army",
@@ -1485,7 +1485,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106876340143815/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Harry Potter and the Order of the Phoenix",
@@ -1498,7 +1498,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570613516994/pikselss.ism",
         "fileFormat": "ism",
         "title": "Hellboy II: The Golden Army",
@@ -1511,7 +1511,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826028051418/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Hansel and Gretel: Witch Hunters",
@@ -1524,7 +1524,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555987457048/pikselss.ism",
         "fileFormat": "ism",
         "title": "Hansel and Gretel: Witch Hunters",
@@ -1537,7 +1537,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843472332289/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Harry Potter and the Order of the Phoenix",
@@ -1550,7 +1550,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561648822753/pikselss.ism",
         "fileFormat": "ism",
         "title": "Hop",
@@ -1563,7 +1563,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873797543919/piksel.mpd",
         "fileFormat": "mpd",
         "title": "High School Musical 3: Senior Year",
@@ -1576,7 +1576,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837557932660/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Harry Potter And The Half Blood Prince",
@@ -1589,7 +1589,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1338/UTV-BOX-15015-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Hector and the Search for Happiness",
@@ -1603,7 +1603,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15234-PI.jpg",
         "fileFormat": "jpg",
         "title": "Happy Feet",
@@ -1616,7 +1616,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15234-LI.jpg",
         "fileFormat": "jpg",
         "title": "Happy Feet",
@@ -1630,7 +1630,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15010-PI.jpg",
         "fileFormat": "jpg",
         "title": "Hansel and Gretel: Witch Hunters",
@@ -1643,7 +1643,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0826/UTV-15105-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Harry Potter And The Deathly Hallows, Part 1",
@@ -1656,7 +1656,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15105-LI.jpg",
         "fileFormat": "jpg",
         "title": "Harry Potter And The Deathly Hallows, Part 1",
@@ -1669,7 +1669,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1408/UTV-15205-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Harry Potter and the Order of the Phoenix",
@@ -1682,7 +1682,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1253/UTV-15171-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "High School Musical 3: Senior Year",
@@ -1695,7 +1695,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15205-LI.jpg",
         "fileFormat": "jpg",
         "title": "Harry Potter and the Order of the Phoenix",
@@ -1709,7 +1709,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15137-PI.jpg",
         "fileFormat": "jpg",
         "title": "Harry Potter And The Half Blood Prince",
@@ -1722,7 +1722,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831847499714/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Harry Potter And The Deathly Hallows, Part 2",
@@ -1735,7 +1735,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561573696099/pikselss.ism",
         "fileFormat": "ism",
         "title": "Harry Potter And The Deathly Hallows, Part 2",
@@ -1748,7 +1748,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879267488113/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Happy Feet",
@@ -1761,7 +1761,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173564894866069/pikselss.ism",
         "fileFormat": "ism",
         "title": "Harry Potter And The Deathly Hallows, Part 1",
@@ -1774,7 +1774,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858489695255/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Hansel and Gretel: Witch Hunters",
@@ -1787,7 +1787,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870440069404/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Harry Potter And The Half Blood Prince",
@@ -1800,7 +1800,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570726070280/pikselss.ism",
         "fileFormat": "ism",
         "title": "High School Musical 3: Senior Year",
@@ -1813,7 +1813,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566897261718/pikselss.ism",
         "fileFormat": "ism",
         "title": "Harry Potter And The Half Blood Prince",
@@ -1826,7 +1826,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831963132978/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Hop",
@@ -1839,7 +1839,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864360989530/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Hop",
@@ -1852,7 +1852,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121840632314527/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Hellboy II: The Golden Army",
@@ -1865,7 +1865,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1602/UTV-15012-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Iron Man 3",
@@ -1878,7 +1878,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15012-LI.jpg",
         "fileFormat": "jpg",
         "title": "Iron Man 3",
@@ -1891,7 +1891,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0830/UTV-15107-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Iron Man 2",
@@ -1904,7 +1904,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1059/UTV-15176-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Iron Man",
@@ -1917,7 +1917,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15176-LI.jpg",
         "fileFormat": "jpg",
         "title": "Iron Man",
@@ -1931,7 +1931,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15176-PI.jpg",
         "fileFormat": "jpg",
         "title": "Iron Man",
@@ -1944,7 +1944,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15011-LI.jpg",
         "fileFormat": "jpg",
         "title": "Insidious: Chapter 2",
@@ -1958,7 +1958,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15011-PI.jpg",
         "fileFormat": "jpg",
         "title": "Insidious: Chapter 2",
@@ -1971,7 +1971,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1600/UTV-15011-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Insidious: Chapter 2",
@@ -1984,7 +1984,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565287466428/pikselss.ism",
         "fileFormat": "ism",
         "title": "Iron Man 2",
@@ -1997,7 +1997,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834877540716/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Iron Man 2",
@@ -2010,7 +2010,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556311473857/pikselss.ism",
         "fileFormat": "ism",
         "title": "Iron Man 3",
@@ -2023,7 +2023,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858570210053/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Insidious: Chapter 2",
@@ -2036,7 +2036,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841199702964/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Iron Man",
@@ -2049,7 +2049,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571520423400/pikselss.ism",
         "fileFormat": "ism",
         "title": "Iron Man",
@@ -2062,7 +2062,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858774873845/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Iron Man 3",
@@ -2075,7 +2075,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826226353205/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Iron Man 3",
@@ -2088,7 +2088,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556070326356/pikselss.ism",
         "fileFormat": "ism",
         "title": "Insidious: Chapter 2",
@@ -2101,7 +2101,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15107-LI.jpg",
         "fileFormat": "jpg",
         "title": "Iron Man 2",
@@ -2115,7 +2115,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15107-PI.jpg",
         "fileFormat": "jpg",
         "title": "Iron Man 2",
@@ -2129,7 +2129,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15012-PI.jpg",
         "fileFormat": "jpg",
         "title": "Iron Man 3",
@@ -2142,7 +2142,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106867561742523/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Iron Man 2",
@@ -2155,7 +2155,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874123600391/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Iron Man",
@@ -2168,7 +2168,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826110158479/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Insidious: Chapter 2",

--- a/test/fixtures/media-items-5.json
+++ b/test/fixtures/media-items-5.json
@@ -13,25 +13,25 @@
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15043%7C%7Csa-team%3AUTV-15142%7C%7Csa-team%3AUTV-15044%7C%7Csa-team%3AUTV-15240&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15043%7C%7Csa-team%3AUTV-15142%7C%7Csa-team%3AUTV-15044%7C%7Csa-team%3AUTV-15240&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15043%7C%7Csa-team%3AUTV-15142%7C%7Csa-team%3AUTV-15044%7C%7Csa-team%3AUTV-15240"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15043%7C%7Csa-team%3AUTV-15142%7C%7Csa-team%3AUTV-15044%7C%7Csa-team%3AUTV-15240&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15043%7C%7Csa-team%3AUTV-15142%7C%7Csa-team%3AUTV-15044%7C%7Csa-team%3AUTV-15240&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15043%7C%7Csa-team%3AUTV-15142%7C%7Csa-team%3AUTV-15044%7C%7Csa-team%3AUTV-15240"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15031%7C%7Csa-team%3AUTV-BOX-15029%7C%7Csa-team%3AUTV-15237%7C%7Csa-team%3AUTV-15039%7C%7Csa-team%3AUTV-15074%7C%7Csa-team%3AUTV-15177%7C%7Csa-team%3AUTV-15013%7C%7Csa-team%3AUTV-15238%7C%7Csa-team%3AUTV-15140%7C%7Csa-team%3AUTV-15075&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15031%7C%7Csa-team%3AUTV-BOX-15029%7C%7Csa-team%3AUTV-15237%7C%7Csa-team%3AUTV-15039%7C%7Csa-team%3AUTV-15074%7C%7Csa-team%3AUTV-15177%7C%7Csa-team%3AUTV-15013%7C%7Csa-team%3AUTV-15238%7C%7Csa-team%3AUTV-15140%7C%7Csa-team%3AUTV-15075&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15031%7C%7Csa-team%3AUTV-BOX-15029%7C%7Csa-team%3AUTV-15237%7C%7Csa-team%3AUTV-15039%7C%7Csa-team%3AUTV-15074%7C%7Csa-team%3AUTV-15177%7C%7Csa-team%3AUTV-15013%7C%7Csa-team%3AUTV-15238%7C%7Csa-team%3AUTV-15140%7C%7Csa-team%3AUTV-15075"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15031%7C%7Csa-team%3AUTV-BOX-15029%7C%7Csa-team%3AUTV-15237%7C%7Csa-team%3AUTV-15039%7C%7Csa-team%3AUTV-15074%7C%7Csa-team%3AUTV-15177%7C%7Csa-team%3AUTV-15013%7C%7Csa-team%3AUTV-15238%7C%7Csa-team%3AUTV-15140%7C%7Csa-team%3AUTV-15075&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15031%7C%7Csa-team%3AUTV-BOX-15029%7C%7Csa-team%3AUTV-15237%7C%7Csa-team%3AUTV-15039%7C%7Csa-team%3AUTV-15074%7C%7Csa-team%3AUTV-15177%7C%7Csa-team%3AUTV-15013%7C%7Csa-team%3AUTV-15238%7C%7Csa-team%3AUTV-15140%7C%7Csa-team%3AUTV-15075&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15031%7C%7Csa-team%3AUTV-BOX-15029%7C%7Csa-team%3AUTV-15237%7C%7Csa-team%3AUTV-15039%7C%7Csa-team%3AUTV-15074%7C%7Csa-team%3AUTV-15177%7C%7Csa-team%3AUTV-15013%7C%7Csa-team%3AUTV-15238%7C%7Csa-team%3AUTV-15140%7C%7Csa-team%3AUTV-15075"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15014%7C%7Csa-team%3AUTV-15076%7C%7Csa-team%3AUTV-15040%7C%7Csa-team%3AUTV-BOX-15046%7C%7Csa-team%3AUTV-15041%7C%7Csa-team%3AUTV-15178%7C%7Csa-team%3AUTV-BOX-15003%7C%7Csa-team%3AUTV-15015%7C%7Csa-team%3AUTV-BOX-15045%7C%7Csa-team%3AUTV-15141&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15014%7C%7Csa-team%3AUTV-15076%7C%7Csa-team%3AUTV-15040%7C%7Csa-team%3AUTV-BOX-15046%7C%7Csa-team%3AUTV-15041%7C%7Csa-team%3AUTV-15178%7C%7Csa-team%3AUTV-BOX-15003%7C%7Csa-team%3AUTV-15015%7C%7Csa-team%3AUTV-BOX-15045%7C%7Csa-team%3AUTV-15141&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15014%7C%7Csa-team%3AUTV-15076%7C%7Csa-team%3AUTV-15040%7C%7Csa-team%3AUTV-BOX-15046%7C%7Csa-team%3AUTV-15041%7C%7Csa-team%3AUTV-15178%7C%7Csa-team%3AUTV-BOX-15003%7C%7Csa-team%3AUTV-15015%7C%7Csa-team%3AUTV-BOX-15045%7C%7Csa-team%3AUTV-15141"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15014%7C%7Csa-team%3AUTV-15076%7C%7Csa-team%3AUTV-15040%7C%7Csa-team%3AUTV-BOX-15046%7C%7Csa-team%3AUTV-15041%7C%7Csa-team%3AUTV-15178%7C%7Csa-team%3AUTV-BOX-15003%7C%7Csa-team%3AUTV-15015%7C%7Csa-team%3AUTV-BOX-15045%7C%7Csa-team%3AUTV-15141&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15014%7C%7Csa-team%3AUTV-15076%7C%7Csa-team%3AUTV-15040%7C%7Csa-team%3AUTV-BOX-15046%7C%7Csa-team%3AUTV-15041%7C%7Csa-team%3AUTV-15178%7C%7Csa-team%3AUTV-BOX-15003%7C%7Csa-team%3AUTV-15015%7C%7Csa-team%3AUTV-BOX-15045%7C%7Csa-team%3AUTV-15141&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15014%7C%7Csa-team%3AUTV-15076%7C%7Csa-team%3AUTV-15040%7C%7Csa-team%3AUTV-BOX-15046%7C%7Csa-team%3AUTV-15041%7C%7Csa-team%3AUTV-15178%7C%7Csa-team%3AUTV-BOX-15003%7C%7Csa-team%3AUTV-15015%7C%7Csa-team%3AUTV-BOX-15045%7C%7Csa-team%3AUTV-15141"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1450/UTV-15240-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Mission: Impossible III",
@@ -324,7 +324,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15240-LI.jpg",
         "fileFormat": "jpg",
         "title": "Mission: Impossible III",
@@ -338,7 +338,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15142-PI.jpg",
         "fileFormat": "jpg",
         "title": "Michael Jackson's This Is It",
@@ -351,7 +351,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0821/UTV-15044-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Mission: Impossible - Ghost Protocol",
@@ -364,7 +364,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15142-LI.jpg",
         "fileFormat": "jpg",
         "title": "Michael Jackson's This Is It",
@@ -377,7 +377,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15044-LI.jpg",
         "fileFormat": "jpg",
         "title": "Mission: Impossible - Ghost Protocol",
@@ -391,7 +391,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15043-PI.jpg",
         "fileFormat": "jpg",
         "title": "Men in Black III",
@@ -404,7 +404,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15043-LI.jpg",
         "fileFormat": "jpg",
         "title": "Men in Black III",
@@ -417,7 +417,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0818/UTV-15043-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Men in Black III",
@@ -430,7 +430,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1013/UTV-15142-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Michael Jackson's This Is It",
@@ -443,7 +443,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838120544417/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Michael Jackson's This Is It",
@@ -456,7 +456,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870995973495/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Michael Jackson's This Is It",
@@ -469,7 +469,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567861400407/pikselss.ism",
         "fileFormat": "ism",
         "title": "Michael Jackson's This Is It",
@@ -482,7 +482,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577209485356/pikselss.ism",
         "fileFormat": "ism",
         "title": "Mission: Impossible III",
@@ -495,7 +495,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879747972514/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Mission: Impossible III",
@@ -508,7 +508,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846471530430/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Mission: Impossible III",
@@ -521,7 +521,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829753947256/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Mission: Impossible - Ghost Protocol",
@@ -534,7 +534,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829663139730/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Men in Black III",
@@ -547,7 +547,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559232304004/pikselss.ism",
         "fileFormat": "ism",
         "title": "Men in Black III",
@@ -560,7 +560,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559598485086/pikselss.ism",
         "fileFormat": "ism",
         "title": "Mission: Impossible - Ghost Protocol",
@@ -573,7 +573,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862013125266/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Mission: Impossible - Ghost Protocol",
@@ -587,7 +587,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15240-PI.jpg",
         "fileFormat": "jpg",
         "title": "Mission: Impossible III",
@@ -601,7 +601,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15044-PI.jpg",
         "fileFormat": "jpg",
         "title": "Mission: Impossible - Ghost Protocol",
@@ -614,7 +614,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861798858107/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Men in Black III",
@@ -627,7 +627,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0805/UTV-15039-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "John Carter",
@@ -641,7 +641,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15039-PI.jpg",
         "fileFormat": "jpg",
         "title": "John Carter",
@@ -654,7 +654,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15039-LI.jpg",
         "fileFormat": "jpg",
         "title": "John Carter",
@@ -667,7 +667,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15031-LI.jpg",
         "fileFormat": "jpg",
         "title": "Jack Ryan: Shadow Recruit",
@@ -680,7 +680,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15238-LI.jpg",
         "fileFormat": "jpg",
         "title": "King Kong",
@@ -693,7 +693,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15013-LI.jpg",
         "fileFormat": "jpg",
         "title": "Kick-Ass 2",
@@ -707,7 +707,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15238-PI.jpg",
         "fileFormat": "jpg",
         "title": "King Kong",
@@ -720,7 +720,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1604/UTV-15013-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Kick-Ass 2",
@@ -733,7 +733,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15074-LI.jpg",
         "fileFormat": "jpg",
         "title": "Johnny English Reborn",
@@ -746,7 +746,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0730/UTV-15074-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Johnny English Reborn",
@@ -760,7 +760,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15074-PI.jpg",
         "fileFormat": "jpg",
         "title": "Johnny English Reborn",
@@ -773,7 +773,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1400/UTV-BOX-15031-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Jack Ryan: Shadow Recruit",
@@ -787,7 +787,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15031-PI.jpg",
         "fileFormat": "jpg",
         "title": "Jack Ryan: Shadow Recruit",
@@ -801,7 +801,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15029-PI.jpg",
         "fileFormat": "jpg",
         "title": "Jack The Giant Slayer",
@@ -814,7 +814,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1447/UTV-15237-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Jarhead",
@@ -827,7 +827,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15029-LI.jpg",
         "fileFormat": "jpg",
         "title": "Jack The Giant Slayer",
@@ -840,7 +840,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1357/UTV-BOX-15029-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Jack The Giant Slayer",
@@ -854,7 +854,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15237-PI.jpg",
         "fileFormat": "jpg",
         "title": "Jarhead",
@@ -867,7 +867,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15237-LI.jpg",
         "fileFormat": "jpg",
         "title": "Jarhead",
@@ -881,7 +881,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15075-PI.jpg",
         "fileFormat": "jpg",
         "title": "Kung Fu Panda 2",
@@ -894,7 +894,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15075-LI.jpg",
         "fileFormat": "jpg",
         "title": "Kung Fu Panda 2",
@@ -907,7 +907,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0732/UTV-15075-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Kung Fu Panda 2",
@@ -921,7 +921,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15177-PI.jpg",
         "fileFormat": "jpg",
         "title": "Jumper",
@@ -934,7 +934,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15140-LI.jpg",
         "fileFormat": "jpg",
         "title": "Knowing",
@@ -947,7 +947,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15177-LI.jpg",
         "fileFormat": "jpg",
         "title": "Jumper",
@@ -960,7 +960,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1307/UTV-15177-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Jumper",
@@ -973,7 +973,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829015431407/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "John Carter",
@@ -986,7 +986,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861444692540/piksel.mpd",
         "fileFormat": "mpd",
         "title": "John Carter",
@@ -999,7 +999,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864527470462/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Johnny English Reborn",
@@ -1012,7 +1012,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846392545836/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "King Kong",
@@ -1025,7 +1025,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562060038284/pikselss.ism",
         "fileFormat": "ism",
         "title": "Johnny English Reborn",
@@ -1038,7 +1038,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556398045832/pikselss.ism",
         "fileFormat": "ism",
         "title": "Kick-Ass 2",
@@ -1051,7 +1051,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826325741221/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Kick-Ass 2",
@@ -1064,7 +1064,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879670478388/piksel.mpd",
         "fileFormat": "mpd",
         "title": "King Kong",
@@ -1077,7 +1077,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577136029526/pikselss.ism",
         "fileFormat": "ism",
         "title": "King Kong",
@@ -1090,7 +1090,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121832288117480/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Johnny English Reborn",
@@ -1103,7 +1103,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846317852736/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Jarhead",
@@ -1116,7 +1116,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577816692206/pikselss.ism",
         "fileFormat": "ism",
         "title": "Jarhead",
@@ -1129,7 +1129,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567623338140/pikselss.ism",
         "fileFormat": "ism",
         "title": "Knowing",
@@ -1142,7 +1142,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837833363764/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Knowing",
@@ -1155,7 +1155,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841306230329/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Jumper",
@@ -1168,7 +1168,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571756555730/pikselss.ism",
         "fileFormat": "ism",
         "title": "Jumper",
@@ -1181,7 +1181,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864615495382/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Kung Fu Panda 2",
@@ -1194,7 +1194,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121832397228996/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Kung Fu Panda 2",
@@ -1207,7 +1207,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562336521176/pikselss.ism",
         "fileFormat": "ism",
         "title": "Kung Fu Panda 2",
@@ -1220,7 +1220,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879454219043/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Jarhead",
@@ -1233,7 +1233,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883598135471/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Jack Ryan: Shadow Recruit",
@@ -1246,7 +1246,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173581744875682/pikselss.ism",
         "fileFormat": "ism",
         "title": "Jack Ryan: Shadow Recruit",
@@ -1259,7 +1259,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850464870922/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Jack The Giant Slayer",
@@ -1273,7 +1273,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15013-PI.jpg",
         "fileFormat": "jpg",
         "title": "Kick-Ass 2",
@@ -1286,7 +1286,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1449/UTV-15238-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "King Kong",
@@ -1300,7 +1300,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15140-PI.jpg",
         "fileFormat": "jpg",
         "title": "Knowing",
@@ -1313,7 +1313,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858851616354/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Kick-Ass 2",
@@ -1326,7 +1326,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558181529065/pikselss.ism",
         "fileFormat": "ism",
         "title": "John Carter",
@@ -1339,7 +1339,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870819404160/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Knowing",
@@ -1352,7 +1352,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874198686388/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Jumper",
@@ -1365,7 +1365,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850653166165/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Jack Ryan: Shadow Recruit",
@@ -1378,7 +1378,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173581279479162/pikselss.ism",
         "fileFormat": "ism",
         "title": "Jack The Giant Slayer",
@@ -1391,7 +1391,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883441820505/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Jack The Giant Slayer",
@@ -1404,7 +1404,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15041-LI.jpg",
         "fileFormat": "jpg",
         "title": "Madagascar 3: Europe's Most Wanted",
@@ -1417,7 +1417,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0841/UTV-BOX-15045-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Mandela: Long Walk to Freedom",
@@ -1430,7 +1430,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1319/UTV-15178-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Madagascar: Escape 2 Africa",
@@ -1444,7 +1444,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15014-PI.jpg",
         "fileFormat": "jpg",
         "title": "Les Miserables - The Movie",
@@ -1457,7 +1457,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15014-LI.jpg",
         "fileFormat": "jpg",
         "title": "Les Miserables - The Movie",
@@ -1471,7 +1471,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15041-PI.jpg",
         "fileFormat": "jpg",
         "title": "Madagascar 3: Europe's Most Wanted",
@@ -1484,7 +1484,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0733/UTV-15076-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Limitless",
@@ -1498,7 +1498,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15076-PI.jpg",
         "fileFormat": "jpg",
         "title": "Limitless",
@@ -1511,7 +1511,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15015-LI.jpg",
         "fileFormat": "jpg",
         "title": "Man of Steel",
@@ -1525,7 +1525,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15015-PI.jpg",
         "fileFormat": "jpg",
         "title": "Man of Steel",
@@ -1539,7 +1539,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15046-PI.jpg",
         "fileFormat": "jpg",
         "title": "Machete Kills",
@@ -1552,7 +1552,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15076-LI.jpg",
         "fileFormat": "jpg",
         "title": "Limitless",
@@ -1565,7 +1565,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0843/UTV-BOX-15046-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Machete Kills",
@@ -1579,7 +1579,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15040-PI.jpg",
         "fileFormat": "jpg",
         "title": "Looper",
@@ -1592,7 +1592,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0808/UTV-15040-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Looper",
@@ -1605,7 +1605,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15040-LI.jpg",
         "fileFormat": "jpg",
         "title": "Looper",
@@ -1618,7 +1618,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1011/UTV-15141-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Marley & Me",
@@ -1631,7 +1631,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15141-LI.jpg",
         "fileFormat": "jpg",
         "title": "Marley & Me",
@@ -1644,7 +1644,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1313/UTV-BOX-15003-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Maleficent",
@@ -1658,7 +1658,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15003-PI.jpg",
         "fileFormat": "jpg",
         "title": "Maleficent",
@@ -1671,7 +1671,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558561086274/pikselss.ism",
         "fileFormat": "ism",
         "title": "Madagascar 3: Europe's Most Wanted",
@@ -1684,7 +1684,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861627404092/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Madagascar 3: Europe's Most Wanted",
@@ -1697,7 +1697,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556636686339/pikselss.ism",
         "fileFormat": "ism",
         "title": "Les Miserables - The Movie",
@@ -1710,7 +1710,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106858940767180/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Les Miserables - The Movie",
@@ -1723,7 +1723,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829414576394/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Madagascar 3: Europe's Most Wanted",
@@ -1736,7 +1736,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106859050763760/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Man of Steel",
@@ -1749,7 +1749,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864693086517/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Limitless",
@@ -1762,7 +1762,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106870908442480/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Marley & Me",
@@ -1775,7 +1775,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121832495922166/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Limitless",
@@ -1788,7 +1788,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556724178687/pikselss.ism",
         "fileFormat": "ism",
         "title": "Man of Steel",
@@ -1801,7 +1801,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826543805732/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Man of Steel",
@@ -1814,7 +1814,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121837910633119/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Marley & Me",
@@ -1827,7 +1827,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173567697358171/pikselss.ism",
         "fileFormat": "ism",
         "title": "Marley & Me",
@@ -1840,7 +1840,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861544220906/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Looper",
@@ -1853,7 +1853,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829124757685/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Looper",
@@ -1866,7 +1866,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558357375704/pikselss.ism",
         "fileFormat": "ism",
         "title": "Looper",
@@ -1879,7 +1879,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841401663295/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Madagascar: Escape 2 Africa",
@@ -1892,7 +1892,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874282876883/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Madagascar: Escape 2 Africa",
@@ -1905,7 +1905,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847901983829/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Maleficent",
@@ -1918,7 +1918,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881017890432/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Maleficent",
@@ -1931,7 +1931,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578651207977/pikselss.ism",
         "fileFormat": "ism",
         "title": "Maleficent",
@@ -1944,7 +1944,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582564283874/pikselss.ism",
         "fileFormat": "ism",
         "title": "Mandela: Long Walk to Freedom",
@@ -1957,7 +1957,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884809399183/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Machete Kills",
@@ -1970,7 +1970,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851889228659/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Mandela: Long Walk to Freedom",
@@ -1983,7 +1983,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582637845585/pikselss.ism",
         "fileFormat": "ism",
         "title": "Machete Kills",
@@ -1996,7 +1996,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0812/UTV-15041-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Madagascar 3: Europe's Most Wanted",
@@ -2010,7 +2010,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15178-PI.jpg",
         "fileFormat": "jpg",
         "title": "Madagascar: Escape 2 Africa",
@@ -2023,7 +2023,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15178-LI.jpg",
         "fileFormat": "jpg",
         "title": "Madagascar: Escape 2 Africa",
@@ -2037,7 +2037,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15045-PI.jpg",
         "fileFormat": "jpg",
         "title": "Mandela: Long Walk to Freedom",
@@ -2050,7 +2050,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15045-LI.jpg",
         "fileFormat": "jpg",
         "title": "Mandela: Long Walk to Freedom",
@@ -2063,7 +2063,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15046-LI.jpg",
         "fileFormat": "jpg",
         "title": "Machete Kills",
@@ -2076,7 +2076,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1608/UTV-15015-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Man of Steel",
@@ -2090,7 +2090,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15141-PI.jpg",
         "fileFormat": "jpg",
         "title": "Marley & Me",
@@ -2103,7 +2103,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15003-LI.jpg",
         "fileFormat": "jpg",
         "title": "Maleficent",
@@ -2116,7 +2116,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562549795584/pikselss.ism",
         "fileFormat": "ism",
         "title": "Limitless",
@@ -2129,7 +2129,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826414163515/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Les Miserables - The Movie",
@@ -2142,7 +2142,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570980653714/pikselss.ism",
         "fileFormat": "ism",
         "title": "Madagascar: Escape 2 Africa",
@@ -2155,7 +2155,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884725300124/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Mandela: Long Walk to Freedom",
@@ -2168,7 +2168,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851966423272/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Machete Kills",

--- a/test/fixtures/media-items-6.json
+++ b/test/fixtures/media-items-6.json
@@ -13,25 +13,25 @@
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15033%7C%7Csa-team%3AUTV-15078%7C%7Csa-team%3AUTV-BOX-15026%7C%7Csa-team%3AUTV-15181&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15033%7C%7Csa-team%3AUTV-15078%7C%7Csa-team%3AUTV-BOX-15026%7C%7Csa-team%3AUTV-15181&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15033%7C%7Csa-team%3AUTV-15078%7C%7Csa-team%3AUTV-BOX-15026%7C%7Csa-team%3AUTV-15181"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15033%7C%7Csa-team%3AUTV-15078%7C%7Csa-team%3AUTV-BOX-15026%7C%7Csa-team%3AUTV-15181&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15033%7C%7Csa-team%3AUTV-15078%7C%7Csa-team%3AUTV-BOX-15026%7C%7Csa-team%3AUTV-15181&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15033%7C%7Csa-team%3AUTV-15078%7C%7Csa-team%3AUTV-BOX-15026%7C%7Csa-team%3AUTV-15181"
         },
         {
           "totalCount": 60,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15017%7C%7Csa-team%3AUTV-15212%7C%7Csa-team%3AUTV-15018%7C%7Csa-team%3AUTV-15019%7C%7Csa-team%3AUTV-15242%7C%7Csa-team%3AUTV-15020%7C%7Csa-team%3AUTV-BOX-15025%7C%7Csa-team%3AUTV-15111%7C%7Csa-team%3AUTV-15146%7C%7Csa-team%3AUTV-15077&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15017%7C%7Csa-team%3AUTV-15212%7C%7Csa-team%3AUTV-15018%7C%7Csa-team%3AUTV-15019%7C%7Csa-team%3AUTV-15242%7C%7Csa-team%3AUTV-15020%7C%7Csa-team%3AUTV-BOX-15025%7C%7Csa-team%3AUTV-15111%7C%7Csa-team%3AUTV-15146%7C%7Csa-team%3AUTV-15077&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15017%7C%7Csa-team%3AUTV-15212%7C%7Csa-team%3AUTV-15018%7C%7Csa-team%3AUTV-15019%7C%7Csa-team%3AUTV-15242%7C%7Csa-team%3AUTV-15020%7C%7Csa-team%3AUTV-BOX-15025%7C%7Csa-team%3AUTV-15111%7C%7Csa-team%3AUTV-15146%7C%7Csa-team%3AUTV-15077"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15017%7C%7Csa-team%3AUTV-15212%7C%7Csa-team%3AUTV-15018%7C%7Csa-team%3AUTV-15019%7C%7Csa-team%3AUTV-15242%7C%7Csa-team%3AUTV-15020%7C%7Csa-team%3AUTV-BOX-15025%7C%7Csa-team%3AUTV-15111%7C%7Csa-team%3AUTV-15146%7C%7Csa-team%3AUTV-15077&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15017%7C%7Csa-team%3AUTV-15212%7C%7Csa-team%3AUTV-15018%7C%7Csa-team%3AUTV-15019%7C%7Csa-team%3AUTV-15242%7C%7Csa-team%3AUTV-15020%7C%7Csa-team%3AUTV-BOX-15025%7C%7Csa-team%3AUTV-15111%7C%7Csa-team%3AUTV-15146%7C%7Csa-team%3AUTV-15077&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15017%7C%7Csa-team%3AUTV-15212%7C%7Csa-team%3AUTV-15018%7C%7Csa-team%3AUTV-15019%7C%7Csa-team%3AUTV-15242%7C%7Csa-team%3AUTV-15020%7C%7Csa-team%3AUTV-BOX-15025%7C%7Csa-team%3AUTV-15111%7C%7Csa-team%3AUTV-15146%7C%7Csa-team%3AUTV-15077"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15016%7C%7Csa-team%3AUTV-15143%7C%7Csa-team%3AUTV-BOX-15042%7C%7Csa-team%3AUTV-15207%7C%7Csa-team%3AUTV-15208%7C%7Csa-team%3AUTV-15110%7C%7Csa-team%3AUTV-15180%7C%7Csa-team%3AUTV-15210%7C%7Csa-team%3AUTV-15241%7C%7Csa-team%3AUTV-15145&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15016%7C%7Csa-team%3AUTV-15143%7C%7Csa-team%3AUTV-BOX-15042%7C%7Csa-team%3AUTV-15207%7C%7Csa-team%3AUTV-15208%7C%7Csa-team%3AUTV-15110%7C%7Csa-team%3AUTV-15180%7C%7Csa-team%3AUTV-15210%7C%7Csa-team%3AUTV-15241%7C%7Csa-team%3AUTV-15145&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15016%7C%7Csa-team%3AUTV-15143%7C%7Csa-team%3AUTV-BOX-15042%7C%7Csa-team%3AUTV-15207%7C%7Csa-team%3AUTV-15208%7C%7Csa-team%3AUTV-15110%7C%7Csa-team%3AUTV-15180%7C%7Csa-team%3AUTV-15210%7C%7Csa-team%3AUTV-15241%7C%7Csa-team%3AUTV-15145"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15016%7C%7Csa-team%3AUTV-15143%7C%7Csa-team%3AUTV-BOX-15042%7C%7Csa-team%3AUTV-15207%7C%7Csa-team%3AUTV-15208%7C%7Csa-team%3AUTV-15110%7C%7Csa-team%3AUTV-15180%7C%7Csa-team%3AUTV-15210%7C%7Csa-team%3AUTV-15241%7C%7Csa-team%3AUTV-15145&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15016%7C%7Csa-team%3AUTV-15143%7C%7Csa-team%3AUTV-BOX-15042%7C%7Csa-team%3AUTV-15207%7C%7Csa-team%3AUTV-15208%7C%7Csa-team%3AUTV-15110%7C%7Csa-team%3AUTV-15180%7C%7Csa-team%3AUTV-15210%7C%7Csa-team%3AUTV-15241%7C%7Csa-team%3AUTV-15145&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15016%7C%7Csa-team%3AUTV-15143%7C%7Csa-team%3AUTV-BOX-15042%7C%7Csa-team%3AUTV-15207%7C%7Csa-team%3AUTV-15208%7C%7Csa-team%3AUTV-15110%7C%7Csa-team%3AUTV-15180%7C%7Csa-team%3AUTV-15210%7C%7Csa-team%3AUTV-15241%7C%7Csa-team%3AUTV-15145"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15026-LI.jpg",
         "fileFormat": "jpg",
         "title": "Percy Jackson: Sea Of Monsters 3D",
@@ -325,7 +325,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15033-PI.jpg",
         "fileFormat": "jpg",
         "title": "Paranormal Activity: The Marked Ones",
@@ -339,7 +339,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15078-PI.jpg",
         "fileFormat": "jpg",
         "title": "Paul",
@@ -352,7 +352,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15078-LI.jpg",
         "fileFormat": "jpg",
         "title": "Paul",
@@ -365,7 +365,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1325/UTV-15181-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Pineapple Express",
@@ -379,7 +379,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15181-PI.jpg",
         "fileFormat": "jpg",
         "title": "Pineapple Express",
@@ -392,7 +392,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874450972623/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Pineapple Express",
@@ -405,7 +405,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571226786871/pikselss.ism",
         "fileFormat": "ism",
         "title": "Pineapple Express",
@@ -418,7 +418,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841581825948/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Pineapple Express",
@@ -431,7 +431,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561895229523/pikselss.ism",
         "fileFormat": "ism",
         "title": "Paul",
@@ -444,7 +444,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864845883347/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Paul",
@@ -457,7 +457,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121832874124034/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Paul",
@@ -470,7 +470,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580683480955/pikselss.ism",
         "fileFormat": "ism",
         "title": "Percy Jackson: Sea Of Monsters 3D",
@@ -483,7 +483,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850232356161/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Percy Jackson: Sea Of Monsters 3D",
@@ -496,7 +496,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883800443113/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Paranormal Activity: The Marked Ones",
@@ -509,7 +509,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850846164830/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Paranormal Activity: The Marked Ones",
@@ -522,7 +522,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1355/UTV-BOX-15026-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Percy Jackson: Sea Of Monsters 3D",
@@ -536,7 +536,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15026-PI.jpg",
         "fileFormat": "jpg",
         "title": "Percy Jackson: Sea Of Monsters 3D",
@@ -549,7 +549,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1403/UTV-BOX-15033-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Paranormal Activity: The Marked Ones",
@@ -562,7 +562,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15033-LI.jpg",
         "fileFormat": "jpg",
         "title": "Paranormal Activity: The Marked Ones",
@@ -575,7 +575,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15181-LI.jpg",
         "fileFormat": "jpg",
         "title": "Pineapple Express",
@@ -588,7 +588,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0735/UTV-15078-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Paul",
@@ -601,7 +601,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883201194701/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Percy Jackson: Sea Of Monsters 3D",
@@ -614,7 +614,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580998630833/pikselss.ism",
         "fileFormat": "ism",
         "title": "Paranormal Activity: The Marked Ones",
@@ -627,7 +627,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15077-LI.jpg",
         "fileFormat": "jpg",
         "title": "Paranormal Activity 3",
@@ -640,7 +640,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15019-LI.jpg",
         "fileFormat": "jpg",
         "title": "One Direction: This Is Us",
@@ -653,7 +653,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15242-LI.jpg",
         "fileFormat": "jpg",
         "title": "Over the Hedge",
@@ -666,7 +666,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1453/UTV-15242-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Over the Hedge",
@@ -679,7 +679,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0952/UTV-15077-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Paranormal Activity 3",
@@ -693,7 +693,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15146-PI.jpg",
         "fileFormat": "jpg",
         "title": "Paranormal Activity",
@@ -706,7 +706,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1020/UTV-15146-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Paranormal Activity",
@@ -719,7 +719,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15146-LI.jpg",
         "fileFormat": "jpg",
         "title": "Paranormal Activity",
@@ -732,7 +732,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1612/UTV-15017-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Oblivion",
@@ -745,7 +745,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15017-LI.jpg",
         "fileFormat": "jpg",
         "title": "Oblivion",
@@ -759,7 +759,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15019-PI.jpg",
         "fileFormat": "jpg",
         "title": "One Direction: This Is Us",
@@ -772,7 +772,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1614/UTV-15018-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Olympus Has Fallen",
@@ -786,7 +786,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15025-PI.jpg",
         "fileFormat": "jpg",
         "title": "Pacific Rim",
@@ -799,7 +799,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15212-LI.jpg",
         "fileFormat": "jpg",
         "title": "Ocean's Thirteen",
@@ -813,7 +813,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15212-PI.jpg",
         "fileFormat": "jpg",
         "title": "Ocean's Thirteen",
@@ -826,7 +826,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15025-LI.jpg",
         "fileFormat": "jpg",
         "title": "Pacific Rim",
@@ -839,7 +839,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1617/UTV-15020-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Oz: The Great And Powerful",
@@ -852,7 +852,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15020-LI.jpg",
         "fileFormat": "jpg",
         "title": "Oz: The Great And Powerful",
@@ -866,7 +866,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15020-PI.jpg",
         "fileFormat": "jpg",
         "title": "Oz: The Great And Powerful",
@@ -879,7 +879,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0835/UTV-15111-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Paranormal Activity",
@@ -893,7 +893,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15111-PI.jpg",
         "fileFormat": "jpg",
         "title": "Paranormal Activity",
@@ -906,7 +906,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15111-LI.jpg",
         "fileFormat": "jpg",
         "title": "Paranormal Activity",
@@ -919,7 +919,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556487064247/pikselss.ism",
         "fileFormat": "ism",
         "title": "One Direction: This Is Us",
@@ -932,7 +932,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826996366641/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "One Direction: This Is Us",
@@ -945,7 +945,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826786120259/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Oblivion",
@@ -958,7 +958,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864766990322/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Paranormal Activity 3",
@@ -971,7 +971,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562783337741/pikselss.ism",
         "fileFormat": "ism",
         "title": "Paranormal Activity 3",
@@ -984,7 +984,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106859229603314/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Oblivion",
@@ -997,7 +997,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577666629097/pikselss.ism",
         "fileFormat": "ism",
         "title": "Over the Hedge",
@@ -1010,7 +1010,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565667348695/pikselss.ism",
         "fileFormat": "ism",
         "title": "Paranormal Activity",
@@ -1023,7 +1023,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173568711485941/pikselss.ism",
         "fileFormat": "ism",
         "title": "Paranormal Activity",
@@ -1036,7 +1036,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826900116529/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Olympus Has Fallen",
@@ -1049,7 +1049,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846773585558/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Over the Hedge",
@@ -1062,7 +1062,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835044318655/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Paranormal Activity",
@@ -1075,7 +1075,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879907474876/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Over the Hedge",
@@ -1088,7 +1088,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121827111035598/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Oz: The Great And Powerful",
@@ -1101,7 +1101,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556235911683/pikselss.ism",
         "fileFormat": "ism",
         "title": "Olympus Has Fallen",
@@ -1114,7 +1114,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843994199753/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Ocean's Thirteen",
@@ -1127,7 +1127,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173574737787812/pikselss.ism",
         "fileFormat": "ism",
         "title": "Ocean's Thirteen",
@@ -1140,7 +1140,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106859321731202/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Olympus Has Fallen",
@@ -1154,7 +1154,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15242-PI.jpg",
         "fileFormat": "jpg",
         "title": "Over the Hedge",
@@ -1167,7 +1167,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1616/UTV-15019-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "One Direction: This Is Us",
@@ -1181,7 +1181,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15077-PI.jpg",
         "fileFormat": "jpg",
         "title": "Paranormal Activity 3",
@@ -1195,7 +1195,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15017-PI.jpg",
         "fileFormat": "jpg",
         "title": "Oblivion",
@@ -1208,7 +1208,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0821/UTV-BOX-15025-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Pacific Rim",
@@ -1221,7 +1221,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15018-LI.jpg",
         "fileFormat": "jpg",
         "title": "Olympus Has Fallen",
@@ -1235,7 +1235,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15018-PI.jpg",
         "fileFormat": "jpg",
         "title": "Olympus Has Fallen",
@@ -1248,7 +1248,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1402/UTV-15212-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Ocean's Thirteen",
@@ -1261,7 +1261,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106859538795591/piksel.mpd",
         "fileFormat": "mpd",
         "title": "One Direction: This Is Us",
@@ -1274,7 +1274,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121832748508257/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Paranormal Activity 3",
@@ -1287,7 +1287,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556159091879/pikselss.ism",
         "fileFormat": "ism",
         "title": "Oblivion",
@@ -1300,7 +1300,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106867772628409/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Paranormal Activity",
@@ -1313,7 +1313,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106871491360777/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Paranormal Activity",
@@ -1326,7 +1326,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877260014602/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Ocean's Thirteen",
@@ -1339,7 +1339,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838436651580/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Paranormal Activity",
@@ -1352,7 +1352,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556562077549/pikselss.ism",
         "fileFormat": "ism",
         "title": "Oz: The Great And Powerful",
@@ -1365,7 +1365,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106859620120433/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Oz: The Great And Powerful",
@@ -1378,7 +1378,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850023593198/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Pacific Rim",
@@ -1391,7 +1391,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580382723912/pikselss.ism",
         "fileFormat": "ism",
         "title": "Pacific Rim",
@@ -1404,7 +1404,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883104385708/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Pacific Rim",
@@ -1417,7 +1417,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1404/UTV-15210-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Night At The Museum",
@@ -1430,7 +1430,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1610/UTV-15016-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Monsters University",
@@ -1443,7 +1443,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15016-LI.jpg",
         "fileFormat": "jpg",
         "title": "Monsters University",
@@ -1457,7 +1457,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15016-PI.jpg",
         "fileFormat": "jpg",
         "title": "Monsters University",
@@ -1470,7 +1470,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15210-LI.jpg",
         "fileFormat": "jpg",
         "title": "Night At The Museum",
@@ -1483,7 +1483,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15180-LI.jpg",
         "fileFormat": "jpg",
         "title": "National Treasure 2: Book Of Secrets",
@@ -1497,7 +1497,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15145-PI.jpg",
         "fileFormat": "jpg",
         "title": "Night At The Museum: Battle of The Smithsonian",
@@ -1510,7 +1510,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15145-LI.jpg",
         "fileFormat": "jpg",
         "title": "Night At The Museum: Battle of The Smithsonian",
@@ -1523,7 +1523,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0833/UTV-15110-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Nanny McPhee & The Big Bang",
@@ -1537,7 +1537,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15110-PI.jpg",
         "fileFormat": "jpg",
         "title": "Nanny McPhee & The Big Bang",
@@ -1551,7 +1551,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15208-PI.jpg",
         "fileFormat": "jpg",
         "title": "Music And Lyrics",
@@ -1564,7 +1564,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1412/UTV-15208-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Music And Lyrics",
@@ -1578,7 +1578,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15207-PI.jpg",
         "fileFormat": "jpg",
         "title": "Mr. Bean's Holiday",
@@ -1591,7 +1591,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1411/UTV-15207-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Mr. Bean's Holiday",
@@ -1604,7 +1604,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15207-LI.jpg",
         "fileFormat": "jpg",
         "title": "Mr. Bean's Holiday",
@@ -1618,7 +1618,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15241-PI.jpg",
         "fileFormat": "jpg",
         "title": "Night At The Museum",
@@ -1632,7 +1632,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15143-PI.jpg",
         "fileFormat": "jpg",
         "title": "Monsters vs Aliens",
@@ -1645,7 +1645,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15143-LI.jpg",
         "fileFormat": "jpg",
         "title": "Monsters vs Aliens",
@@ -1658,7 +1658,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1451/UTV-15241-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Night At The Museum",
@@ -1671,7 +1671,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173568075527924/pikselss.ism",
         "fileFormat": "ism",
         "title": "Night At The Museum: Battle of The Smithsonian",
@@ -1684,7 +1684,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106867685782683/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Nanny McPhee & The Big Bang",
@@ -1697,7 +1697,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838358744238/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Night At The Museum: Battle of The Smithsonian",
@@ -1710,7 +1710,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834957751095/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Nanny McPhee & The Big Bang",
@@ -1723,7 +1723,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571061848486/pikselss.ism",
         "fileFormat": "ism",
         "title": "National Treasure 2: Book Of Secrets",
@@ -1736,7 +1736,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874372522498/piksel.mpd",
         "fileFormat": "mpd",
         "title": "National Treasure 2: Book Of Secrets",
@@ -1749,7 +1749,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841500469453/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "National Treasure 2: Book Of Secrets",
@@ -1762,7 +1762,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106859148550154/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Monsters University",
@@ -1775,7 +1775,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555913368169/pikselss.ism",
         "fileFormat": "ism",
         "title": "Monsters University",
@@ -1788,7 +1788,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843790095487/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Night At The Museum",
@@ -1801,7 +1801,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843626191163/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Mr. Bean's Holiday",
@@ -1814,7 +1814,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877020640495/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Mr. Bean's Holiday",
@@ -1827,7 +1827,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173568276143015/pikselss.ism",
         "fileFormat": "ism",
         "title": "Monsters vs Aliens",
@@ -1840,7 +1840,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173574046989169/pikselss.ism",
         "fileFormat": "ism",
         "title": "Mr. Bean's Holiday",
@@ -1853,7 +1853,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838197655257/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Monsters vs Aliens",
@@ -1866,7 +1866,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106871200223456/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Monsters vs Aliens",
@@ -1879,7 +1879,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577407074285/pikselss.ism",
         "fileFormat": "ism",
         "title": "Night At The Museum",
@@ -1892,7 +1892,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573892848658/pikselss.ism",
         "fileFormat": "ism",
         "title": "Music And Lyrics",
@@ -1905,7 +1905,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846548498472/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Night At The Museum",
@@ -1918,7 +1918,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573967056415/pikselss.ism",
         "fileFormat": "ism",
         "title": "Night At The Museum",
@@ -1931,7 +1931,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106879822283745/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Night At The Museum",
@@ -1944,7 +1944,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877094471892/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Music And Lyrics",
@@ -1957,7 +1957,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851457840713/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Mortal Instruments: City Of Bones",
@@ -1970,7 +1970,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173581915854721/pikselss.ism",
         "fileFormat": "ism",
         "title": "Mortal Instruments: City Of Bones",
@@ -1983,7 +1983,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884478508271/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Mortal Instruments: City Of Bones",
@@ -1996,7 +1996,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15042-LI.jpg",
         "fileFormat": "jpg",
         "title": "Mortal Instruments: City Of Bones",
@@ -2009,7 +2009,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1416/UTV-BOX-15042-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Mortal Instruments: City Of Bones",
@@ -2023,7 +2023,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15042-PI.jpg",
         "fileFormat": "jpg",
         "title": "Mortal Instruments: City Of Bones",
@@ -2037,7 +2037,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15210-PI.jpg",
         "fileFormat": "jpg",
         "title": "Night At The Museum",
@@ -2051,7 +2051,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15180-PI.jpg",
         "fileFormat": "jpg",
         "title": "National Treasure 2: Book Of Secrets",
@@ -2064,7 +2064,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1321/UTV-15180-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "National Treasure 2: Book Of Secrets",
@@ -2077,7 +2077,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15208-LI.jpg",
         "fileFormat": "jpg",
         "title": "Music And Lyrics",
@@ -2090,7 +2090,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1017/UTV-15145-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Night At The Museum: Battle of The Smithsonian",
@@ -2103,7 +2103,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15110-LI.jpg",
         "fileFormat": "jpg",
         "title": "Nanny McPhee & The Big Bang",
@@ -2116,7 +2116,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15241-LI.jpg",
         "fileFormat": "jpg",
         "title": "Night At The Museum",
@@ -2129,7 +2129,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565531448119/pikselss.ism",
         "fileFormat": "ism",
         "title": "Nanny McPhee & The Big Bang",
@@ -2142,7 +2142,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106871404291169/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Night At The Museum: Battle of The Smithsonian",
@@ -2155,7 +2155,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121826661507959/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Monsters University",
@@ -2168,7 +2168,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877181852198/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Night At The Museum",
@@ -2181,7 +2181,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121843706745505/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Music And Lyrics",

--- a/test/fixtures/media-items-7.json
+++ b/test/fixtures/media-items-7.json
@@ -13,25 +13,25 @@
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15244%7C%7Csa-team%3AUTV-15114%7C%7Csa-team%3AUTV-BOX-15041%7C%7Csa-team%3AUTV-15084&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15244%7C%7Csa-team%3AUTV-15114%7C%7Csa-team%3AUTV-BOX-15041%7C%7Csa-team%3AUTV-15084&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15244%7C%7Csa-team%3AUTV-15114%7C%7Csa-team%3AUTV-BOX-15041%7C%7Csa-team%3AUTV-15084"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15244%7C%7Csa-team%3AUTV-15114%7C%7Csa-team%3AUTV-BOX-15041%7C%7Csa-team%3AUTV-15084&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15244%7C%7Csa-team%3AUTV-15114%7C%7Csa-team%3AUTV-BOX-15041%7C%7Csa-team%3AUTV-15084&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15244%7C%7Csa-team%3AUTV-15114%7C%7Csa-team%3AUTV-BOX-15041%7C%7Csa-team%3AUTV-15084"
         },
         {
           "totalCount": 60,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15040%7C%7Csa-team%3AUTV-15082%7C%7Csa-team%3AUTV-BOX-15008%7C%7Csa-team%3AUTV-15083%7C%7Csa-team%3AUTV-15183%7C%7Csa-team%3AUTV-15215%7C%7Csa-team%3AUTV-15147%7C%7Csa-team%3AUTV-15216%7C%7Csa-team%3AUTV-BOX-15048%7C%7Csa-team%3AUTV-15217&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15040%7C%7Csa-team%3AUTV-15082%7C%7Csa-team%3AUTV-BOX-15008%7C%7Csa-team%3AUTV-15083%7C%7Csa-team%3AUTV-15183%7C%7Csa-team%3AUTV-15215%7C%7Csa-team%3AUTV-15147%7C%7Csa-team%3AUTV-15216%7C%7Csa-team%3AUTV-BOX-15048%7C%7Csa-team%3AUTV-15217&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15040%7C%7Csa-team%3AUTV-15082%7C%7Csa-team%3AUTV-BOX-15008%7C%7Csa-team%3AUTV-15083%7C%7Csa-team%3AUTV-15183%7C%7Csa-team%3AUTV-15215%7C%7Csa-team%3AUTV-15147%7C%7Csa-team%3AUTV-15216%7C%7Csa-team%3AUTV-BOX-15048%7C%7Csa-team%3AUTV-15217"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15040%7C%7Csa-team%3AUTV-15082%7C%7Csa-team%3AUTV-BOX-15008%7C%7Csa-team%3AUTV-15083%7C%7Csa-team%3AUTV-15183%7C%7Csa-team%3AUTV-15215%7C%7Csa-team%3AUTV-15147%7C%7Csa-team%3AUTV-15216%7C%7Csa-team%3AUTV-BOX-15048%7C%7Csa-team%3AUTV-15217&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15040%7C%7Csa-team%3AUTV-15082%7C%7Csa-team%3AUTV-BOX-15008%7C%7Csa-team%3AUTV-15083%7C%7Csa-team%3AUTV-15183%7C%7Csa-team%3AUTV-15215%7C%7Csa-team%3AUTV-15147%7C%7Csa-team%3AUTV-15216%7C%7Csa-team%3AUTV-BOX-15048%7C%7Csa-team%3AUTV-15217&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15040%7C%7Csa-team%3AUTV-15082%7C%7Csa-team%3AUTV-BOX-15008%7C%7Csa-team%3AUTV-15083%7C%7Csa-team%3AUTV-15183%7C%7Csa-team%3AUTV-15215%7C%7Csa-team%3AUTV-15147%7C%7Csa-team%3AUTV-15216%7C%7Csa-team%3AUTV-BOX-15048%7C%7Csa-team%3AUTV-15217"
         },
         {
           "totalCount": 57,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15213%7C%7Csa-team%3AUTV-15243%7C%7Csa-team%3AUTV-15079%7C%7Csa-team%3AUTV-15046%7C%7Csa-team%3AUTV-15080%7C%7Csa-team%3AUTV-15182%7C%7Csa-team%3AUTV-15081%7C%7Csa-team%3AUTV-15214%7C%7Csa-team%3AUTV-BOX-15028%7C%7Csa-team%3AUTV-15112&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15213%7C%7Csa-team%3AUTV-15243%7C%7Csa-team%3AUTV-15079%7C%7Csa-team%3AUTV-15046%7C%7Csa-team%3AUTV-15080%7C%7Csa-team%3AUTV-15182%7C%7Csa-team%3AUTV-15081%7C%7Csa-team%3AUTV-15214%7C%7Csa-team%3AUTV-BOX-15028%7C%7Csa-team%3AUTV-15112&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15213%7C%7Csa-team%3AUTV-15243%7C%7Csa-team%3AUTV-15079%7C%7Csa-team%3AUTV-15046%7C%7Csa-team%3AUTV-15080%7C%7Csa-team%3AUTV-15182%7C%7Csa-team%3AUTV-15081%7C%7Csa-team%3AUTV-15214%7C%7Csa-team%3AUTV-BOX-15028%7C%7Csa-team%3AUTV-15112"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15213%7C%7Csa-team%3AUTV-15243%7C%7Csa-team%3AUTV-15079%7C%7Csa-team%3AUTV-15046%7C%7Csa-team%3AUTV-15080%7C%7Csa-team%3AUTV-15182%7C%7Csa-team%3AUTV-15081%7C%7Csa-team%3AUTV-15214%7C%7Csa-team%3AUTV-BOX-15028%7C%7Csa-team%3AUTV-15112&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15213%7C%7Csa-team%3AUTV-15243%7C%7Csa-team%3AUTV-15079%7C%7Csa-team%3AUTV-15046%7C%7Csa-team%3AUTV-15080%7C%7Csa-team%3AUTV-15182%7C%7Csa-team%3AUTV-15081%7C%7Csa-team%3AUTV-15214%7C%7Csa-team%3AUTV-BOX-15028%7C%7Csa-team%3AUTV-15112&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15213%7C%7Csa-team%3AUTV-15243%7C%7Csa-team%3AUTV-15079%7C%7Csa-team%3AUTV-15046%7C%7Csa-team%3AUTV-15080%7C%7Csa-team%3AUTV-15182%7C%7Csa-team%3AUTV-15081%7C%7Csa-team%3AUTV-15214%7C%7Csa-team%3AUTV-BOX-15028%7C%7Csa-team%3AUTV-15112"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1455/UTV-15244-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Saw 3",
@@ -325,7 +325,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15244-PI.jpg",
         "fileFormat": "jpg",
         "title": "Saw 3",
@@ -338,7 +338,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15244-LI.jpg",
         "fileFormat": "jpg",
         "title": "Saw 3",
@@ -351,7 +351,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15041-LI.jpg",
         "fileFormat": "jpg",
         "title": "Scary Movie 5",
@@ -365,7 +365,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15041-PI.jpg",
         "fileFormat": "jpg",
         "title": "Scary Movie 5",
@@ -379,7 +379,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15084-PI.jpg",
         "fileFormat": "jpg",
         "title": "Scream 4",
@@ -392,7 +392,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15114-LI.jpg",
         "fileFormat": "jpg",
         "title": "Saw 3D",
@@ -405,7 +405,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0747/UTV-15084-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Scream 4",
@@ -419,7 +419,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15114-PI.jpg",
         "fileFormat": "jpg",
         "title": "Saw 3D",
@@ -432,7 +432,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15084-LI.jpg",
         "fileFormat": "jpg",
         "title": "Scream 4",
@@ -445,7 +445,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835200339317/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Saw 3D",
@@ -458,7 +458,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833544213929/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Scream 4",
@@ -471,7 +471,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106868066832490/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Saw 3D",
@@ -484,7 +484,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846945072981/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Saw 3",
@@ -497,7 +497,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577976801339/pikselss.ism",
         "fileFormat": "ism",
         "title": "Saw 3",
@@ -510,7 +510,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851379904407/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Scary Movie 5",
@@ -523,7 +523,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884388310547/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Scary Movie 5",
@@ -536,7 +536,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1414/UTV-BOX-15041-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Scary Movie 5",
@@ -549,7 +549,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1013/UTV-15114-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Saw 3D",
@@ -562,7 +562,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565136928016/pikselss.ism",
         "fileFormat": "ism",
         "title": "Saw 3D",
@@ -575,7 +575,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563161857485/pikselss.ism",
         "fileFormat": "ism",
         "title": "Scream 4",
@@ -588,7 +588,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880200221672/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Saw 3",
@@ -601,7 +601,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865338835169/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Scream 4",
@@ -614,7 +614,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582477475546/pikselss.ism",
         "fileFormat": "ism",
         "title": "Scary Movie 5",
@@ -627,7 +627,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1330/UTV-15183-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "RocknRolla",
@@ -641,7 +641,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15183-PI.jpg",
         "fileFormat": "jpg",
         "title": "RocknRolla",
@@ -654,7 +654,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15217-LI.jpg",
         "fileFormat": "jpg",
         "title": "Rush Hour 3",
@@ -668,7 +668,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15215-PI.jpg",
         "fileFormat": "jpg",
         "title": "Rocky Balboa",
@@ -681,7 +681,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1417/UTV-15215-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Rocky Balboa",
@@ -695,7 +695,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15217-PI.jpg",
         "fileFormat": "jpg",
         "title": "Rush Hour 3",
@@ -708,7 +708,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0847/UTV-BOX-15048-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Runner, Runner",
@@ -722,7 +722,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15048-PI.jpg",
         "fileFormat": "jpg",
         "title": "Runner, Runner",
@@ -735,7 +735,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15083-LI.jpg",
         "fileFormat": "jpg",
         "title": "Rise Of The Planet Of The Apes",
@@ -749,7 +749,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15083-PI.jpg",
         "fileFormat": "jpg",
         "title": "Rise Of The Planet Of The Apes",
@@ -762,7 +762,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15082-LI.jpg",
         "fileFormat": "jpg",
         "title": "Rio",
@@ -775,7 +775,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15008-LI.jpg",
         "fileFormat": "jpg",
         "title": "Rio 2",
@@ -789,7 +789,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15082-PI.jpg",
         "fileFormat": "jpg",
         "title": "Rio",
@@ -802,7 +802,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1325/UTV-BOX-15008-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Rio 2",
@@ -815,7 +815,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0833/UTV-BOX-15040-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Riddick",
@@ -828,7 +828,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0742/UTV-15082-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Rio",
@@ -841,7 +841,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0744/UTV-15083-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Rise Of The Planet Of The Apes",
@@ -854,7 +854,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15040-LI.jpg",
         "fileFormat": "jpg",
         "title": "Riddick",
@@ -867,7 +867,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1124/UTV-15216-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Run Fatboy Run",
@@ -880,7 +880,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15147-LI.jpg",
         "fileFormat": "jpg",
         "title": "Role Models",
@@ -893,7 +893,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1023/UTV-15147-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Role Models",
@@ -906,7 +906,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562868186576/pikselss.ism",
         "fileFormat": "ism",
         "title": "Rise Of The Planet Of The Apes",
@@ -919,7 +919,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833467373178/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Rise Of The Planet Of The Apes",
@@ -932,7 +932,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865263030023/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Rise Of The Planet Of The Apes",
@@ -945,7 +945,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877721182340/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Rush Hour 3",
@@ -958,7 +958,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877648208770/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Run Fatboy Run",
@@ -971,7 +971,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841740408483/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "RocknRolla",
@@ -984,7 +984,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571682247713/pikselss.ism",
         "fileFormat": "ism",
         "title": "RocknRolla",
@@ -997,7 +997,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874617527805/piksel.mpd",
         "fileFormat": "mpd",
         "title": "RocknRolla",
@@ -1010,7 +1010,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865175359324/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Rio",
@@ -1023,7 +1023,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844231170444/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Rocky Balboa",
@@ -1036,7 +1036,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833391494155/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Rio",
@@ -1049,7 +1049,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106871566942301/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Role Models",
@@ -1062,7 +1062,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562708228256/pikselss.ism",
         "fileFormat": "ism",
         "title": "Rio",
@@ -1075,7 +1075,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844311208088/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Run Fatboy Run",
@@ -1088,7 +1088,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881632859984/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Rio 2",
@@ -1101,7 +1101,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848297082240/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Rio 2",
@@ -1114,7 +1114,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579490056810/pikselss.ism",
         "fileFormat": "ism",
         "title": "Rio 2",
@@ -1127,7 +1127,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582381001018/pikselss.ism",
         "fileFormat": "ism",
         "title": "Riddick",
@@ -1140,7 +1140,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884290893766/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Riddick",
@@ -1153,7 +1153,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121852119165931/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Runner, Runner",
@@ -1166,7 +1166,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173583002799293/pikselss.ism",
         "fileFormat": "ism",
         "title": "Runner, Runner",
@@ -1179,7 +1179,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884977625551/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Runner, Runner",
@@ -1192,7 +1192,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15183-LI.jpg",
         "fileFormat": "jpg",
         "title": "RocknRolla",
@@ -1205,7 +1205,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15048-LI.jpg",
         "fileFormat": "jpg",
         "title": "Runner, Runner",
@@ -1218,7 +1218,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1418/UTV-15217-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Rush Hour 3",
@@ -1231,7 +1231,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15215-LI.jpg",
         "fileFormat": "jpg",
         "title": "Rocky Balboa",
@@ -1245,7 +1245,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15040-PI.jpg",
         "fileFormat": "jpg",
         "title": "Riddick",
@@ -1259,7 +1259,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15008-PI.jpg",
         "fileFormat": "jpg",
         "title": "Rio 2",
@@ -1273,7 +1273,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15216-PI.jpg",
         "fileFormat": "jpg",
         "title": "Run Fatboy Run",
@@ -1286,7 +1286,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15216-LI.jpg",
         "fileFormat": "jpg",
         "title": "Run Fatboy Run",
@@ -1300,7 +1300,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15147-PI.jpg",
         "fileFormat": "jpg",
         "title": "Role Models",
@@ -1313,7 +1313,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844399999639/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Rush Hour 3",
@@ -1326,7 +1326,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173575029263931/pikselss.ism",
         "fileFormat": "ism",
         "title": "Rush Hour 3",
@@ -1339,7 +1339,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569033384427/pikselss.ism",
         "fileFormat": "ism",
         "title": "Role Models",
@@ -1352,7 +1352,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838524627105/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Role Models",
@@ -1365,7 +1365,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173574952737118/pikselss.ism",
         "fileFormat": "ism",
         "title": "Run Fatboy Run",
@@ -1378,7 +1378,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877572964443/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Rocky Balboa",
@@ -1391,7 +1391,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173575355618104/pikselss.ism",
         "fileFormat": "ism",
         "title": "Rocky Balboa",
@@ -1404,7 +1404,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851304584167/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Riddick",
@@ -1417,7 +1417,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0825/UTV-BOX-15028-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Red 2",
@@ -1430,7 +1430,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15079-LI.jpg",
         "fileFormat": "jpg",
         "title": "Pirates of the Caribbean: On Stranger Tides",
@@ -1444,7 +1444,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15079-PI.jpg",
         "fileFormat": "jpg",
         "title": "Pirates of the Caribbean: On Stranger Tides",
@@ -1457,7 +1457,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0737/UTV-15079-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Pirates of the Caribbean: On Stranger Tides",
@@ -1471,7 +1471,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15046-PI.jpg",
         "fileFormat": "jpg",
         "title": "Prometheus",
@@ -1484,7 +1484,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0655/UTV-15046-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Prometheus",
@@ -1497,7 +1497,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15046-LI.jpg",
         "fileFormat": "jpg",
         "title": "Prometheus",
@@ -1511,7 +1511,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15214-PI.jpg",
         "fileFormat": "jpg",
         "title": "Ratatouille",
@@ -1524,7 +1524,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15112-LI.jpg",
         "fileFormat": "jpg",
         "title": "Resident Evil: Afterlife",
@@ -1537,7 +1537,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0738/UTV-15080-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Puss In Boots",
@@ -1550,7 +1550,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15182-LI.jpg",
         "fileFormat": "jpg",
         "title": "Quantum Of Solace",
@@ -1564,7 +1564,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15213-PI.jpg",
         "fileFormat": "jpg",
         "title": "Pirates of the Caribbean: At World's End",
@@ -1577,7 +1577,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15213-LI.jpg",
         "fileFormat": "jpg",
         "title": "Pirates of the Caribbean: At World's End",
@@ -1590,7 +1590,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15243-LI.jpg",
         "fileFormat": "jpg",
         "title": "Pirates Of The Caribbean: Dead Man's Chest",
@@ -1604,7 +1604,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15243-PI.jpg",
         "fileFormat": "jpg",
         "title": "Pirates Of The Caribbean: Dead Man's Chest",
@@ -1618,7 +1618,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15081-PI.jpg",
         "fileFormat": "jpg",
         "title": "Rango",
@@ -1631,7 +1631,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0741/UTV-15081-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Rango",
@@ -1644,7 +1644,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835119918758/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Resident Evil: Afterlife",
@@ -1657,7 +1657,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173564975171615/pikselss.ism",
         "fileFormat": "ism",
         "title": "Resident Evil: Afterlife",
@@ -1670,7 +1670,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106867987248933/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Resident Evil: Afterlife",
@@ -1683,7 +1683,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829842827836/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Prometheus",
@@ -1696,7 +1696,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559685302892/pikselss.ism",
         "fileFormat": "ism",
         "title": "Prometheus",
@@ -1709,7 +1709,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121832962655413/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Pirates of the Caribbean: On Stranger Tides",
@@ -1722,7 +1722,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106864933691646/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Pirates of the Caribbean: On Stranger Tides",
@@ -1735,7 +1735,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173575192446973/pikselss.ism",
         "fileFormat": "ism",
         "title": "Ratatouille",
@@ -1748,7 +1748,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877450130407/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Ratatouille",
@@ -1761,7 +1761,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571608516549/pikselss.ism",
         "fileFormat": "ism",
         "title": "Quantum Of Solace",
@@ -1774,7 +1774,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173575103815444/pikselss.ism",
         "fileFormat": "ism",
         "title": "Pirates of the Caribbean: At World's End",
@@ -1787,7 +1787,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562223526738/pikselss.ism",
         "fileFormat": "ism",
         "title": "Puss In Boots",
@@ -1800,7 +1800,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562634708586/pikselss.ism",
         "fileFormat": "ism",
         "title": "Rango",
@@ -1813,7 +1813,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841659134305/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Quantum Of Solace",
@@ -1826,7 +1826,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877354073784/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Pirates of the Caribbean: At World's End",
@@ -1839,7 +1839,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121846866043419/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Pirates Of The Caribbean: Dead Man's Chest",
@@ -1852,7 +1852,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173577741354341/pikselss.ism",
         "fileFormat": "ism",
         "title": "Pirates Of The Caribbean: Dead Man's Chest",
@@ -1865,7 +1865,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883354406904/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Red 2",
@@ -1878,7 +1878,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850389125460/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Red 2",
@@ -1891,7 +1891,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580912685555/pikselss.ism",
         "fileFormat": "ism",
         "title": "Red 2",
@@ -1905,7 +1905,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15028-PI.jpg",
         "fileFormat": "jpg",
         "title": "Red 2",
@@ -1918,7 +1918,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15028-LI.jpg",
         "fileFormat": "jpg",
         "title": "Red 2",
@@ -1931,7 +1931,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15214-LI.jpg",
         "fileFormat": "jpg",
         "title": "Ratatouille",
@@ -1945,7 +1945,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15112-PI.jpg",
         "fileFormat": "jpg",
         "title": "Resident Evil: Afterlife",
@@ -1958,7 +1958,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1010/UTV-15112-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Resident Evil: Afterlife",
@@ -1972,7 +1972,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15182-PI.jpg",
         "fileFormat": "jpg",
         "title": "Quantum Of Solace",
@@ -1985,7 +1985,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1328/UTV-15182-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Quantum Of Solace",
@@ -1998,7 +1998,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15080-LI.jpg",
         "fileFormat": "jpg",
         "title": "Puss In Boots",
@@ -2012,7 +2012,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15080-PI.jpg",
         "fileFormat": "jpg",
         "title": "Puss In Boots",
@@ -2025,7 +2025,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15081-LI.jpg",
         "fileFormat": "jpg",
         "title": "Rango",
@@ -2038,7 +2038,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173562150017029/pikselss.ism",
         "fileFormat": "ism",
         "title": "Pirates of the Caribbean: On Stranger Tides",
@@ -2051,7 +2051,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844149267071/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Ratatouille",
@@ -2064,7 +2064,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862096638712/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Prometheus",
@@ -2077,7 +2077,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865087325351/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Rango",
@@ -2090,7 +2090,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833151992463/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Rango",
@@ -2103,7 +2103,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865009307903/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Puss In Boots",
@@ -2116,7 +2116,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833064240320/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Puss In Boots",
@@ -2129,7 +2129,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874526614255/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Quantum Of Solace",
@@ -2142,7 +2142,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844069216713/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Pirates of the Caribbean: At World's End",
@@ -2155,7 +2155,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880123194145/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Pirates Of The Caribbean: Dead Man's Chest",

--- a/test/fixtures/media-items-8.json
+++ b/test/fixtures/media-items-8.json
@@ -13,25 +13,25 @@
           "totalCount": 58,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15184%7C%7Csa-team%3AUTV-15115%7C%7Csa-team%3AUTV-15085%7C%7Csa-team%3AUTV-15116%7C%7Csa-team%3AUTV-15218%7C%7Csa-team%3AUTV-BOX-15032%7C%7Csa-team%3AUTV-15048%7C%7Csa-team%3AUTV-15148%7C%7Csa-team%3AUTV-15245%7C%7Csa-team%3AUTV-15219&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15184%7C%7Csa-team%3AUTV-15115%7C%7Csa-team%3AUTV-15085%7C%7Csa-team%3AUTV-15116%7C%7Csa-team%3AUTV-15218%7C%7Csa-team%3AUTV-BOX-15032%7C%7Csa-team%3AUTV-15048%7C%7Csa-team%3AUTV-15148%7C%7Csa-team%3AUTV-15245%7C%7Csa-team%3AUTV-15219&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15184%7C%7Csa-team%3AUTV-15115%7C%7Csa-team%3AUTV-15085%7C%7Csa-team%3AUTV-15116%7C%7Csa-team%3AUTV-15218%7C%7Csa-team%3AUTV-BOX-15032%7C%7Csa-team%3AUTV-15048%7C%7Csa-team%3AUTV-15148%7C%7Csa-team%3AUTV-15245%7C%7Csa-team%3AUTV-15219"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15184%7C%7Csa-team%3AUTV-15115%7C%7Csa-team%3AUTV-15085%7C%7Csa-team%3AUTV-15116%7C%7Csa-team%3AUTV-15218%7C%7Csa-team%3AUTV-BOX-15032%7C%7Csa-team%3AUTV-15048%7C%7Csa-team%3AUTV-15148%7C%7Csa-team%3AUTV-15245%7C%7Csa-team%3AUTV-15219&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15184%7C%7Csa-team%3AUTV-15115%7C%7Csa-team%3AUTV-15085%7C%7Csa-team%3AUTV-15116%7C%7Csa-team%3AUTV-15218%7C%7Csa-team%3AUTV-BOX-15032%7C%7Csa-team%3AUTV-15048%7C%7Csa-team%3AUTV-15148%7C%7Csa-team%3AUTV-15245%7C%7Csa-team%3AUTV-15219&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15184%7C%7Csa-team%3AUTV-15115%7C%7Csa-team%3AUTV-15085%7C%7Csa-team%3AUTV-15116%7C%7Csa-team%3AUTV-15218%7C%7Csa-team%3AUTV-BOX-15032%7C%7Csa-team%3AUTV-15048%7C%7Csa-team%3AUTV-15148%7C%7Csa-team%3AUTV-15245%7C%7Csa-team%3AUTV-15219"
         },
         {
           "totalCount": 15,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15047%7C%7Csa-team%3AssOmai22%7C%7Csa-team%3AssOmai23%7C%7Csa-team%3AssOmai24%7C%7Csa-team%3AssOmai25%7C%7Csa-team%3AssOmai26%7C%7Csa-team%3AssOmai27%7C%7Csa-team%3AssOmai28%7C%7Csa-team%3AssOmai29%7C%7Csa-team%3AssOmai9&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15047%7C%7Csa-team%3AssOmai22%7C%7Csa-team%3AssOmai23%7C%7Csa-team%3AssOmai24%7C%7Csa-team%3AssOmai25%7C%7Csa-team%3AssOmai26%7C%7Csa-team%3AssOmai27%7C%7Csa-team%3AssOmai28%7C%7Csa-team%3AssOmai29%7C%7Csa-team%3AssOmai9&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15047%7C%7Csa-team%3AssOmai22%7C%7Csa-team%3AssOmai23%7C%7Csa-team%3AssOmai24%7C%7Csa-team%3AssOmai25%7C%7Csa-team%3AssOmai26%7C%7Csa-team%3AssOmai27%7C%7Csa-team%3AssOmai28%7C%7Csa-team%3AssOmai29%7C%7Csa-team%3AssOmai9"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15047%7C%7Csa-team%3AssOmai22%7C%7Csa-team%3AssOmai23%7C%7Csa-team%3AssOmai24%7C%7Csa-team%3AssOmai25%7C%7Csa-team%3AssOmai26%7C%7Csa-team%3AssOmai27%7C%7Csa-team%3AssOmai28%7C%7Csa-team%3AssOmai29%7C%7Csa-team%3AssOmai9&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15047%7C%7Csa-team%3AssOmai22%7C%7Csa-team%3AssOmai23%7C%7Csa-team%3AssOmai24%7C%7Csa-team%3AssOmai25%7C%7Csa-team%3AssOmai26%7C%7Csa-team%3AssOmai27%7C%7Csa-team%3AssOmai28%7C%7Csa-team%3AssOmai29%7C%7Csa-team%3AssOmai9&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15047%7C%7Csa-team%3AssOmai22%7C%7Csa-team%3AssOmai23%7C%7Csa-team%3AssOmai24%7C%7Csa-team%3AssOmai25%7C%7Csa-team%3AssOmai26%7C%7Csa-team%3AssOmai27%7C%7Csa-team%3AssOmai28%7C%7Csa-team%3AssOmai29%7C%7Csa-team%3AssOmai9"
         },
         {
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15149%7C%7Csa-team%3AUTV-15023%7C%7Csa-team%3AUTV-15150%7C%7Csa-team%3AUTV-15185&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15149%7C%7Csa-team%3AUTV-15023%7C%7Csa-team%3AUTV-15150%7C%7Csa-team%3AUTV-15185&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15149%7C%7Csa-team%3AUTV-15023%7C%7Csa-team%3AUTV-15150%7C%7Csa-team%3AUTV-15185"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15149%7C%7Csa-team%3AUTV-15023%7C%7Csa-team%3AUTV-15150%7C%7Csa-team%3AUTV-15185&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15149%7C%7Csa-team%3AUTV-15023%7C%7Csa-team%3AUTV-15150%7C%7Csa-team%3AUTV-15185&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15149%7C%7Csa-team%3AUTV-15023%7C%7Csa-team%3AUTV-15150%7C%7Csa-team%3AUTV-15185"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1425/UTV-15219-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Spider-Man 3",
@@ -324,7 +324,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1402/UTV-BOX-15032-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Sin City: A Dame To Kill For",
@@ -337,7 +337,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1457/UTV-15245-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Snakes On A Plane",
@@ -350,7 +350,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15184-LI.jpg",
         "fileFormat": "jpg",
         "title": "Sex And The City",
@@ -363,7 +363,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15219-LI.jpg",
         "fileFormat": "jpg",
         "title": "Spider-Man 3",
@@ -377,7 +377,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15116-PI.jpg",
         "fileFormat": "jpg",
         "title": "Shrek Forever After",
@@ -391,7 +391,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15184-PI.jpg",
         "fileFormat": "jpg",
         "title": "Sex And The City",
@@ -405,7 +405,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15032-PI.jpg",
         "fileFormat": "jpg",
         "title": "Sin City: A Dame To Kill For",
@@ -418,7 +418,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15032-LI.jpg",
         "fileFormat": "jpg",
         "title": "Sin City: A Dame To Kill For",
@@ -432,7 +432,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15245-PI.jpg",
         "fileFormat": "jpg",
         "title": "Snakes On A Plane",
@@ -445,7 +445,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0846/UTV-15116-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Shrek Forever After",
@@ -459,7 +459,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15048-PI.jpg",
         "fileFormat": "jpg",
         "title": "Skyfall",
@@ -472,7 +472,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15048-LI.jpg",
         "fileFormat": "jpg",
         "title": "Skyfall",
@@ -485,7 +485,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1420/UTV-15218-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Shrek The Third",
@@ -498,7 +498,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15218-LI.jpg",
         "fileFormat": "jpg",
         "title": "Shrek The Third",
@@ -511,7 +511,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0829/UTV-15048-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Skyfall",
@@ -525,7 +525,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15085-PI.jpg",
         "fileFormat": "jpg",
         "title": "Sherlock Holmes: A Game of Shadows",
@@ -538,7 +538,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0748/UTV-15085-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Sherlock Holmes: A Game of Shadows",
@@ -551,7 +551,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15115-LI.jpg",
         "fileFormat": "jpg",
         "title": "Sex and the City 2",
@@ -565,7 +565,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15148-PI.jpg",
         "fileFormat": "jpg",
         "title": "Slumdog Millionaire",
@@ -578,7 +578,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15148-LI.jpg",
         "fileFormat": "jpg",
         "title": "Slumdog Millionaire",
@@ -592,7 +592,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15115-PI.jpg",
         "fileFormat": "jpg",
         "title": "Sex and the City 2",
@@ -605,7 +605,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1025/UTV-15148-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Slumdog Millionaire",
@@ -618,7 +618,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576103337584/pikselss.ism",
         "fileFormat": "ism",
         "title": "Spider-Man 3",
@@ -631,7 +631,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106868283363809/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Shrek Forever After",
@@ -644,7 +644,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835508133034/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Shrek Forever After",
@@ -657,7 +657,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829920510283/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Skyfall",
@@ -670,7 +670,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844689437275/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Spider-Man 3",
@@ -683,7 +683,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565211639778/pikselss.ism",
         "fileFormat": "ism",
         "title": "Sex and the City 2",
@@ -696,7 +696,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106865417178365/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Sherlock Holmes: A Game of Shadows",
@@ -709,7 +709,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565381116956/pikselss.ism",
         "fileFormat": "ism",
         "title": "Shrek Forever After",
@@ -722,7 +722,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862180192244/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Skyfall",
@@ -735,7 +735,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844610034737/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Shrek The Third",
@@ -748,7 +748,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877806718740/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Shrek The Third",
@@ -761,7 +761,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880272844909/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Snakes On A Plane",
@@ -774,7 +774,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578067591347/pikselss.ism",
         "fileFormat": "ism",
         "title": "Snakes On A Plane",
@@ -787,7 +787,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874705223702/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Sex And The City",
@@ -800,7 +800,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847032148278/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Snakes On A Plane",
@@ -813,7 +813,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121833624506601/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Sherlock Holmes: A Game of Shadows",
@@ -826,7 +826,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106871771639649/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Slumdog Millionaire",
@@ -839,7 +839,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173563249407590/pikselss.ism",
         "fileFormat": "ism",
         "title": "Sherlock Holmes: A Game of Shadows",
@@ -852,7 +852,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838735710638/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Slumdog Millionaire",
@@ -865,7 +865,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841825503832/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Sex And The City",
@@ -878,7 +878,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173575279269995/pikselss.ism",
         "fileFormat": "ism",
         "title": "Shrek The Third",
@@ -891,7 +891,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883694517553/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Sin City: A Dame To Kill For",
@@ -904,7 +904,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173581830284440/pikselss.ism",
         "fileFormat": "ism",
         "title": "Sin City: A Dame To Kill For",
@@ -917,7 +917,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15245-LI.jpg",
         "fileFormat": "jpg",
         "title": "Snakes On A Plane",
@@ -931,7 +931,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15219-PI.jpg",
         "fileFormat": "jpg",
         "title": "Spider-Man 3",
@@ -944,7 +944,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15116-LI.jpg",
         "fileFormat": "jpg",
         "title": "Shrek Forever After",
@@ -958,7 +958,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15218-PI.jpg",
         "fileFormat": "jpg",
         "title": "Shrek The Third",
@@ -971,7 +971,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15085-LI.jpg",
         "fileFormat": "jpg",
         "title": "Sherlock Holmes: A Game of Shadows",
@@ -984,7 +984,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877903720198/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Spider-Man 3",
@@ -997,7 +997,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835290563520/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Sex and the City 2",
@@ -1010,7 +1010,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106868194298304/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Sex and the City 2",
@@ -1023,7 +1023,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558867279077/pikselss.ism",
         "fileFormat": "ism",
         "title": "Skyfall",
@@ -1036,7 +1036,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173571847311383/pikselss.ism",
         "fileFormat": "ism",
         "title": "Sex And The City",
@@ -1049,7 +1049,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569187041174/pikselss.ism",
         "fileFormat": "ism",
         "title": "Slumdog Millionaire",
@@ -1062,7 +1062,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121850768697853/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Sin City: A Dame To Kill For",
@@ -1075,7 +1075,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15047-LI.jpg",
         "fileFormat": "jpg",
         "title": "Spring Breakers",
@@ -1089,7 +1089,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15047-PI.jpg",
         "fileFormat": "jpg",
         "title": "Spring Breakers",
@@ -1102,7 +1102,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0845/UTV-BOX-15047-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Spring Breakers",
@@ -1115,7 +1115,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai24.ism",
         "fileFormat": "ism",
         "title": "ssOmai24",
@@ -1128,7 +1128,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai27.ism",
         "fileFormat": "ism",
         "title": "ssOmai27",
@@ -1141,7 +1141,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai22.ism",
         "fileFormat": "ism",
         "title": "ssOmai22",
@@ -1154,7 +1154,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai29.ism",
         "fileFormat": "ism",
         "title": "ssOmai29",
@@ -1167,7 +1167,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai26.ism",
         "fileFormat": "ism",
         "title": "ssOmai26",
@@ -1180,7 +1180,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai9.ism",
         "fileFormat": "ism",
         "title": "ssOmai9",
@@ -1193,7 +1193,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121852042400606/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Spring Breakers",
@@ -1206,7 +1206,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884898621199/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Spring Breakers",
@@ -1219,7 +1219,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582917396397/pikselss.ism",
         "fileFormat": "ism",
         "title": "Spring Breakers",
@@ -1232,7 +1232,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai28.ism",
         "fileFormat": "ism",
         "title": "ssOmai28",
@@ -1245,7 +1245,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai23.ism",
         "fileFormat": "ism",
         "title": "ssOmai23",
@@ -1258,7 +1258,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2015/10/06/1430/ssOmai25.ism",
         "fileFormat": "ism",
         "title": "ssOmai25",
@@ -1271,7 +1271,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1027/UTV-15149-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Star Trek",
@@ -1284,7 +1284,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15149-LI.jpg",
         "fileFormat": "jpg",
         "title": "Star Trek",
@@ -1297,7 +1297,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15023-LI.jpg",
         "fileFormat": "jpg",
         "title": "Star Trek Into Darkness",
@@ -1310,7 +1310,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1333/UTV-15185-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Step Brothers",
@@ -1324,7 +1324,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15185-PI.jpg",
         "fileFormat": "jpg",
         "title": "Step Brothers",
@@ -1338,7 +1338,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15023-PI.jpg",
         "fileFormat": "jpg",
         "title": "Star Trek Into Darkness",
@@ -1352,7 +1352,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15150-PI.jpg",
         "fileFormat": "jpg",
         "title": "State Of Play",
@@ -1365,7 +1365,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1029/UTV-15150-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "State Of Play",
@@ -1378,7 +1378,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15150-LI.jpg",
         "fileFormat": "jpg",
         "title": "State Of Play",
@@ -1391,7 +1391,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106871847788229/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Star Trek",
@@ -1404,7 +1404,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841908950140/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Step Brothers",
@@ -1417,7 +1417,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572064651945/pikselss.ism",
         "fileFormat": "ism",
         "title": "Step Brothers",
@@ -1430,7 +1430,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556810123979/pikselss.ism",
         "fileFormat": "ism",
         "title": "Star Trek Into Darkness",
@@ -1443,7 +1443,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569515882126/pikselss.ism",
         "fileFormat": "ism",
         "title": "State Of Play",
@@ -1456,7 +1456,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838891855130/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "State Of Play",
@@ -1470,7 +1470,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15149-PI.jpg",
         "fileFormat": "jpg",
         "title": "Star Trek",
@@ -1483,7 +1483,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15185-LI.jpg",
         "fileFormat": "jpg",
         "title": "Step Brothers",
@@ -1496,7 +1496,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1630/UTV-15023-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Star Trek Into Darkness",
@@ -1509,7 +1509,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106871937126656/piksel.mpd",
         "fileFormat": "mpd",
         "title": "State Of Play",
@@ -1522,7 +1522,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838813596259/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Star Trek",
@@ -1535,7 +1535,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569273410559/pikselss.ism",
         "fileFormat": "ism",
         "title": "Star Trek",
@@ -1548,7 +1548,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874780632724/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Step Brothers",
@@ -1561,7 +1561,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106859694749421/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Star Trek Into Darkness",
@@ -1574,7 +1574,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121827226999074/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Star Trek Into Darkness",

--- a/test/fixtures/media-items-9.json
+++ b/test/fixtures/media-items-9.json
@@ -13,25 +13,25 @@
           "totalCount": 57,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15017%7C%7Csa-team%3AUTV-15117%7C%7Csa-team%3AUTV-15186%7C%7Csa-team%3AUTV-15058%7C%7Csa-team%3AUTV-15049%7C%7Csa-team%3AUTV-15246%7C%7Csa-team%3AUTV-BOX-15036%7C%7Csa-team%3AUTV-15050%7C%7Csa-team%3AUTV-15151%7C%7Csa-team%3ATITL0000000000760859&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15017%7C%7Csa-team%3AUTV-15117%7C%7Csa-team%3AUTV-15186%7C%7Csa-team%3AUTV-15058%7C%7Csa-team%3AUTV-15049%7C%7Csa-team%3AUTV-15246%7C%7Csa-team%3AUTV-BOX-15036%7C%7Csa-team%3AUTV-15050%7C%7Csa-team%3AUTV-15151%7C%7Csa-team%3ATITL0000000000760859&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15017%7C%7Csa-team%3AUTV-15117%7C%7Csa-team%3AUTV-15186%7C%7Csa-team%3AUTV-15058%7C%7Csa-team%3AUTV-15049%7C%7Csa-team%3AUTV-15246%7C%7Csa-team%3AUTV-BOX-15036%7C%7Csa-team%3AUTV-15050%7C%7Csa-team%3AUTV-15151%7C%7Csa-team%3ATITL0000000000760859"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15017%7C%7Csa-team%3AUTV-15117%7C%7Csa-team%3AUTV-15186%7C%7Csa-team%3AUTV-15058%7C%7Csa-team%3AUTV-15049%7C%7Csa-team%3AUTV-15246%7C%7Csa-team%3AUTV-BOX-15036%7C%7Csa-team%3AUTV-15050%7C%7Csa-team%3AUTV-15151%7C%7Csa-team%3ATITL0000000000760859&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15017%7C%7Csa-team%3AUTV-15117%7C%7Csa-team%3AUTV-15186%7C%7Csa-team%3AUTV-15058%7C%7Csa-team%3AUTV-15049%7C%7Csa-team%3AUTV-15246%7C%7Csa-team%3AUTV-BOX-15036%7C%7Csa-team%3AUTV-15050%7C%7Csa-team%3AUTV-15151%7C%7Csa-team%3ATITL0000000000760859&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-BOX-15017%7C%7Csa-team%3AUTV-15117%7C%7Csa-team%3AUTV-15186%7C%7Csa-team%3AUTV-15058%7C%7Csa-team%3AUTV-15049%7C%7Csa-team%3AUTV-15246%7C%7Csa-team%3AUTV-BOX-15036%7C%7Csa-team%3AUTV-15050%7C%7Csa-team%3AUTV-15151%7C%7Csa-team%3ATITL0000000000760859"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15051%7C%7Csa-team%3AUTV-BOX-15005%7C%7Csa-team%3AUTV-15042%7C%7Csa-team%3AUTV-15052%7C%7Csa-team%3AUTV-BOX-15049%7C%7Csa-team%3AUTV-15220%7C%7Csa-team%3AUTV-15188%7C%7Csa-team%3AUTV-15118%7C%7Csa-team%3AUTV-BOX-15023%7C%7Csa-team%3AUTV-15024&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15051%7C%7Csa-team%3AUTV-BOX-15005%7C%7Csa-team%3AUTV-15042%7C%7Csa-team%3AUTV-15052%7C%7Csa-team%3AUTV-BOX-15049%7C%7Csa-team%3AUTV-15220%7C%7Csa-team%3AUTV-15188%7C%7Csa-team%3AUTV-15118%7C%7Csa-team%3AUTV-BOX-15023%7C%7Csa-team%3AUTV-15024&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15051%7C%7Csa-team%3AUTV-BOX-15005%7C%7Csa-team%3AUTV-15042%7C%7Csa-team%3AUTV-15052%7C%7Csa-team%3AUTV-BOX-15049%7C%7Csa-team%3AUTV-15220%7C%7Csa-team%3AUTV-15188%7C%7Csa-team%3AUTV-15118%7C%7Csa-team%3AUTV-BOX-15023%7C%7Csa-team%3AUTV-15024"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15051%7C%7Csa-team%3AUTV-BOX-15005%7C%7Csa-team%3AUTV-15042%7C%7Csa-team%3AUTV-15052%7C%7Csa-team%3AUTV-BOX-15049%7C%7Csa-team%3AUTV-15220%7C%7Csa-team%3AUTV-15188%7C%7Csa-team%3AUTV-15118%7C%7Csa-team%3AUTV-BOX-15023%7C%7Csa-team%3AUTV-15024&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15051%7C%7Csa-team%3AUTV-BOX-15005%7C%7Csa-team%3AUTV-15042%7C%7Csa-team%3AUTV-15052%7C%7Csa-team%3AUTV-BOX-15049%7C%7Csa-team%3AUTV-15220%7C%7Csa-team%3AUTV-15188%7C%7Csa-team%3AUTV-15118%7C%7Csa-team%3AUTV-BOX-15023%7C%7Csa-team%3AUTV-15024&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15051%7C%7Csa-team%3AUTV-BOX-15005%7C%7Csa-team%3AUTV-15042%7C%7Csa-team%3AUTV-15052%7C%7Csa-team%3AUTV-BOX-15049%7C%7Csa-team%3AUTV-15220%7C%7Csa-team%3AUTV-15188%7C%7Csa-team%3AUTV-15118%7C%7Csa-team%3AUTV-BOX-15023%7C%7Csa-team%3AUTV-15024"
         },
         {
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15152%7C%7Csa-team%3AUTV-15189%7C%7Csa-team%3AUTV-15053%7C%7Csa-team%3AUTV-15190&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15152%7C%7Csa-team%3AUTV-15189%7C%7Csa-team%3AUTV-15053%7C%7Csa-team%3AUTV-15190&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15152%7C%7Csa-team%3AUTV-15189%7C%7Csa-team%3AUTV-15053%7C%7Csa-team%3AUTV-15190"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15152%7C%7Csa-team%3AUTV-15189%7C%7Csa-team%3AUTV-15053%7C%7Csa-team%3AUTV-15190&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15152%7C%7Csa-team%3AUTV-15189%7C%7Csa-team%3AUTV-15053%7C%7Csa-team%3AUTV-15190&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15152%7C%7Csa-team%3AUTV-15189%7C%7Csa-team%3AUTV-15053%7C%7Csa-team%3AUTV-15190"
         }
       ]
     }
@@ -311,7 +311,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1341/UTV-BOX-15017-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Step Up: All In",
@@ -325,7 +325,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15017-PI.jpg",
         "fileFormat": "jpg",
         "title": "Step Up: All In",
@@ -338,7 +338,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15049-LI.jpg",
         "fileFormat": "jpg",
         "title": "Taken 2",
@@ -351,7 +351,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15050-LI.jpg",
         "fileFormat": "jpg",
         "title": "Ted",
@@ -364,7 +364,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1335/UTV-15186-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Sweeney Todd: The Demon Barber Of Fleet Street",
@@ -377,7 +377,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0658/UTV-15049-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Taken 2",
@@ -391,7 +391,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15049-PI.jpg",
         "fileFormat": "jpg",
         "title": "Taken 2",
@@ -404,7 +404,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1410/UTV-BOX-15036-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Tammy And The Bachelor",
@@ -418,7 +418,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15151-PI.jpg",
         "fileFormat": "jpg",
         "title": "Terminator Salvation",
@@ -431,7 +431,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15151-LI.jpg",
         "fileFormat": "jpg",
         "title": "Terminator Salvation",
@@ -444,7 +444,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/TITL0000000000760859-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Adjustment Bureau",
@@ -458,7 +458,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/TITL0000000000760859-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Adjustment Bureau",
@@ -471,7 +471,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15246-LI.jpg",
         "fileFormat": "jpg",
         "title": "Talladega Nights: The Ballad Of Ricky Bobby",
@@ -485,7 +485,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15036-PI.jpg",
         "fileFormat": "jpg",
         "title": "Tammy And The Bachelor",
@@ -498,7 +498,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15036-LI.jpg",
         "fileFormat": "jpg",
         "title": "Tammy And The Bachelor",
@@ -511,7 +511,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1458/UTV-15246-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Talladega Nights: The Ballad Of Ricky Bobby",
@@ -524,7 +524,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0857/UTV-15058-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Sweeney!",
@@ -537,7 +537,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0850/UTV-15117-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "StreetDance",
@@ -550,7 +550,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15117-LI.jpg",
         "fileFormat": "jpg",
         "title": "StreetDance",
@@ -563,7 +563,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15058-LI.jpg",
         "fileFormat": "jpg",
         "title": "Sweeney!",
@@ -576,7 +576,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862347693922/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Ted",
@@ -589,7 +589,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559070334285/pikselss.ism",
         "fileFormat": "ism",
         "title": "Taken 2",
@@ -602,7 +602,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882410476333/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Step Up: All In",
@@ -615,7 +615,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849211815369/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Step Up: All In",
@@ -628,7 +628,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121838970539080/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Terminator Salvation",
@@ -641,7 +641,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/2014/12/03/0758/pikselcorporate.ism",
         "fileFormat": "ism",
         "title": "The Adjustment Bureau",
@@ -654,7 +654,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872013976036/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Terminator Salvation",
@@ -667,7 +667,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569601701101/pikselss.ism",
         "fileFormat": "ism",
         "title": "Terminator Salvation",
@@ -680,7 +680,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830740350768/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Sweeney!",
@@ -693,7 +693,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863173992087/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Sweeney!",
@@ -706,7 +706,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106880361847858/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Talladega Nights: The Ballad Of Ricky Bobby",
@@ -719,7 +719,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121847118054843/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Talladega Nights: The Ballad Of Ricky Bobby",
@@ -732,7 +732,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572336058591/pikselss.ism",
         "fileFormat": "ism",
         "title": "Sweeney Todd: The Demon Barber Of Fleet Street",
@@ -745,7 +745,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874855205616/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Sweeney Todd: The Demon Barber Of Fleet Street",
@@ -758,7 +758,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121841984781428/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Sweeney Todd: The Demon Barber Of Fleet Street",
@@ -771,7 +771,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851000603722/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Tammy And The Bachelor",
@@ -784,7 +784,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106883950932423/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Tammy And The Bachelor",
@@ -797,7 +797,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173581464211628/pikselss.ism",
         "fileFormat": "ism",
         "title": "Tammy And The Bachelor",
@@ -810,7 +810,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15017-LI.jpg",
         "fileFormat": "jpg",
         "title": "Step Up: All In",
@@ -823,7 +823,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15186-LI.jpg",
         "fileFormat": "jpg",
         "title": "Sweeney Todd: The Demon Barber Of Fleet Street",
@@ -837,7 +837,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15186-PI.jpg",
         "fileFormat": "jpg",
         "title": "Sweeney Todd: The Demon Barber Of Fleet Street",
@@ -851,7 +851,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15050-PI.jpg",
         "fileFormat": "jpg",
         "title": "Ted",
@@ -864,7 +864,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0700/UTV-15050-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Ted",
@@ -878,7 +878,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15246-PI.jpg",
         "fileFormat": "jpg",
         "title": "Talladega Nights: The Ballad Of Ricky Bobby",
@@ -891,7 +891,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1030/UTV-15151-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Terminator Salvation",
@@ -905,7 +905,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15058-PI.jpg",
         "fileFormat": "jpg",
         "title": "Sweeney!",
@@ -919,7 +919,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15117-PI.jpg",
         "fileFormat": "jpg",
         "title": "StreetDance",
@@ -932,7 +932,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862271200708/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Taken 2",
@@ -945,7 +945,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829999316623/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Taken 2",
@@ -958,7 +958,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830075127757/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Ted",
@@ -971,7 +971,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559322101111/pikselss.ism",
         "fileFormat": "ism",
         "title": "Ted",
@@ -984,7 +984,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579856700273/pikselss.ism",
         "fileFormat": "ism",
         "title": "Step Up: All In",
@@ -997,7 +997,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173578374656656/pikselss.ism",
         "fileFormat": "ism",
         "title": "Talladega Nights: The Ballad Of Ricky Bobby",
@@ -1010,7 +1010,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106868360217641/piksel.mpd",
         "fileFormat": "mpd",
         "title": "StreetDance",
@@ -1023,7 +1023,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835584604316/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "StreetDance",
@@ -1036,7 +1036,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173565456375470/pikselss.ism",
         "fileFormat": "ism",
         "title": "StreetDance",
@@ -1049,7 +1049,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173560208633388/pikselss.ism",
         "fileFormat": "ism",
         "title": "Sweeney!",
@@ -1062,7 +1062,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15042-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Avengers",
@@ -1075,7 +1075,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15024-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Croods",
@@ -1089,7 +1089,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15042-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Avengers",
@@ -1102,7 +1102,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1631/UTV-15024-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Croods",
@@ -1116,7 +1116,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15024-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Croods",
@@ -1129,7 +1129,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1319/UTV-BOX-15005-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Amazing Spider-Man 2",
@@ -1143,7 +1143,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15005-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Amazing Spider-Man 2",
@@ -1156,7 +1156,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0848/UTV-BOX-15049-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Book Thief",
@@ -1170,7 +1170,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15049-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Book Thief",
@@ -1183,7 +1183,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15049-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Book Thief",
@@ -1196,7 +1196,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0701/UTV-15051-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Amazing Spider-Man",
@@ -1209,7 +1209,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0704/UTV-15052-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Best Exotic Marigold Hotel",
@@ -1222,7 +1222,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15023-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Conjuring",
@@ -1236,7 +1236,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15052-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Best Exotic Marigold Hotel",
@@ -1249,7 +1249,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15052-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Best Exotic Marigold Hotel",
@@ -1262,7 +1262,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15220-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Bourne Ultimatum",
@@ -1275,7 +1275,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15118-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Chronicles of Narnia: The Voyage of the Dawn Treader",
@@ -1288,7 +1288,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0852/UTV-15118-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Chronicles of Narnia: The Voyage of the Dawn Treader",
@@ -1301,7 +1301,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1427/UTV-15220-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Bourne Ultimatum",
@@ -1315,7 +1315,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15188-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Chronicles of Narnia: Prince Caspian",
@@ -1328,7 +1328,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1337/UTV-15188-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Chronicles of Narnia: Prince Caspian",
@@ -1341,7 +1341,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15188-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Chronicles of Narnia: Prince Caspian",
@@ -1354,7 +1354,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121827365627270/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Croods",
@@ -1367,7 +1367,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559144829359/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Avengers",
@@ -1380,7 +1380,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173556964587588/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Croods",
@@ -1393,7 +1393,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106859797098631/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Croods",
@@ -1406,7 +1406,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861710915853/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Avengers",
@@ -1419,7 +1419,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121829541398408/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Avengers",
@@ -1432,7 +1432,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173559523299884/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Amazing Spider-Man",
@@ -1445,7 +1445,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830151805590/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Amazing Spider-Man",
@@ -1458,7 +1458,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862424073605/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Amazing Spider-Man",
@@ -1471,7 +1471,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842063433102/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Chronicles of Narnia: Prince Caspian",
@@ -1484,7 +1484,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572421539543/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Chronicles of Narnia: Prince Caspian",
@@ -1497,7 +1497,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106874943824544/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Chronicles of Narnia: Prince Caspian",
@@ -1510,7 +1510,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173560043525655/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Best Exotic Marigold Hotel",
@@ -1523,7 +1523,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566068601675/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Chronicles of Narnia: The Voyage of the Dawn Treader",
@@ -1536,7 +1536,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121835708044130/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Chronicles of Narnia: The Voyage of the Dawn Treader",
@@ -1549,7 +1549,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121844776625753/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Bourne Ultimatum",
@@ -1562,7 +1562,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862654750005/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Best Exotic Marigold Hotel",
@@ -1575,7 +1575,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106877977940307/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Bourne Ultimatum",
@@ -1588,7 +1588,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849859200218/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Conjuring",
@@ -1601,7 +1601,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882950324703/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Conjuring",
@@ -1614,7 +1614,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580017026689/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Conjuring",
@@ -1627,7 +1627,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121852320309351/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Book Thief",
@@ -1640,7 +1640,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15051-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Amazing Spider-Man",
@@ -1654,7 +1654,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15051-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Amazing Spider-Man",
@@ -1667,7 +1667,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15005-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Amazing Spider-Man 2",
@@ -1681,7 +1681,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15023-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Conjuring",
@@ -1694,7 +1694,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1709/UTV-BOX-15023-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Conjuring",
@@ -1708,7 +1708,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15220-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Bourne Ultimatum",
@@ -1722,7 +1722,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15118-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Chronicles of Narnia: The Voyage of the Dawn Treader",
@@ -1735,7 +1735,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106868588070440/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Chronicles of Narnia: The Voyage of the Dawn Treader",
@@ -1748,7 +1748,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173576189710830/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Bourne Ultimatum",
@@ -1761,7 +1761,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830234341272/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Best Exotic Marigold Hotel",
@@ -1774,7 +1774,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881332169365/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Amazing Spider-Man 2",
@@ -1787,7 +1787,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579083957482/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Amazing Spider-Man 2",
@@ -1800,7 +1800,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848058331277/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Amazing Spider-Man 2",
@@ -1813,7 +1813,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106885054522568/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Book Thief",
@@ -1826,7 +1826,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173583237740523/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Book Thief",
@@ -1839,7 +1839,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15053-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Dark Knight Rises",
@@ -1853,7 +1853,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15053-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Dark Knight Rises",
@@ -1866,7 +1866,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0706/UTV-15053-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Dark Knight Rises",
@@ -1879,7 +1879,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15189-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Dark Knight",
@@ -1892,7 +1892,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1339/UTV-15189-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Dark Knight",
@@ -1905,7 +1905,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15152-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Curious Case Of Benjamin Button",
@@ -1919,7 +1919,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15152-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Curious Case Of Benjamin Button",
@@ -1932,7 +1932,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1033/UTV-15152-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Curious Case Of Benjamin Button",
@@ -1945,7 +1945,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1340/UTV-15190-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "The Day The Earth Stood Still",
@@ -1958,7 +1958,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106872088752664/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Curious Case Of Benjamin Button",
@@ -1971,7 +1971,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173569841597494/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Curious Case Of Benjamin Button",
@@ -1984,7 +1984,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572581113637/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Dark Knight",
@@ -1997,7 +1997,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875031097414/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Dark Knight",
@@ -2010,7 +2010,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842144256864/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Dark Knight",
@@ -2023,7 +2023,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106862779836907/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Dark Knight Rises",
@@ -2036,7 +2036,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173572740314773/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Day The Earth Stood Still",
@@ -2050,7 +2050,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15189-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Dark Knight",
@@ -2063,7 +2063,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15190-LI.jpg",
         "fileFormat": "jpg",
         "title": "The Day The Earth Stood Still",
@@ -2077,7 +2077,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15190-PI.jpg",
         "fileFormat": "jpg",
         "title": "The Day The Earth Stood Still",
@@ -2090,7 +2090,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839052098536/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Curious Case Of Benjamin Button",
@@ -2103,7 +2103,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173560122980385/pikselss.ism",
         "fileFormat": "ism",
         "title": "The Dark Knight Rises",
@@ -2116,7 +2116,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121830313957619/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Dark Knight Rises",
@@ -2129,7 +2129,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842226205124/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "The Day The Earth Stood Still",
@@ -2142,7 +2142,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875108105933/piksel.mpd",
         "fileFormat": "mpd",
         "title": "The Day The Earth Stood Still",

--- a/test/fixtures/media-items.json
+++ b/test/fixtures/media-items.json
@@ -12,25 +12,25 @@
           "totalCount": 24,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15065%7C%7Csa-team%3AUTV-15034%7C%7Csa-team%3AUTV-15131%7C%7Csa-team%3AUTV-15035"
         },
         {
           "totalCount": 60,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15162%7C%7Csa-team%3AUTV-BOX-15019%7C%7Csa-team%3AUTV-15127%7C%7Csa-team%3AUTV-BOX-15006%7C%7Csa-team%3AUTV-15163%7C%7Csa-team%3AUTV-BOX-15011%7C%7Csa-team%3AUTV-15128%7C%7Csa-team%3AUTV-15000%7C%7Csa-team%3AUTV-15001%7C%7Csa-team%3AUTV-15033"
         },
         {
           "totalCount": 59,
           "page": 1,
           "perPage": 100,
-          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061&page=1&perPage=100",
-          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061&page=1&perPage=100",
-          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2CmediaType%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061"
+          "first": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061&page=1&perPage=100",
+          "last": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061&page=1&perPage=100",
+          "request": "/data/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=sa-team%3AUTV-15002%7C%7Csa-team%3AUTV-15003%7C%7Csa-team%3AUTV-15096%7C%7Csa-team%3AUTV-15164%7C%7Csa-team%3AUTV-15129%7C%7Csa-team%3AUTV-15199%7C%7Csa-team%3AUTV-BOX-15038%7C%7Csa-team%3AUTV-15130%7C%7Csa-team%3AUTV-15064%7C%7Csa-team%3AUTV-15061"
         }
       ]
     }
@@ -308,7 +308,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15035-LI.jpg",
         "fileFormat": "jpg",
         "title": "Brave",
@@ -321,7 +321,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0650/UTV-15035-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Brave",
@@ -335,7 +335,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15035-PI.jpg",
         "fileFormat": "jpg",
         "title": "Brave",
@@ -348,7 +348,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0648/UTV-15034-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Battleship",
@@ -361,7 +361,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0940/UTV-15131-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Bolt",
@@ -375,7 +375,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15131-PI.jpg",
         "fileFormat": "jpg",
         "title": "Bolt",
@@ -388,7 +388,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15131-LI.jpg",
         "fileFormat": "jpg",
         "title": "Bolt",
@@ -401,7 +401,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15065-LI.jpg",
         "fileFormat": "jpg",
         "title": "Battle: Los Angeles",
@@ -415,7 +415,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15034-PI.jpg",
         "fileFormat": "jpg",
         "title": "Battleship",
@@ -428,7 +428,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836992003025/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Bolt",
@@ -441,7 +441,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566971287429/pikselss.ism",
         "fileFormat": "ism",
         "title": "Bolt",
@@ -454,7 +454,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869851017493/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Bolt",
@@ -467,7 +467,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828566459997/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Battleship",
@@ -480,7 +480,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558654354725/pikselss.ism",
         "fileFormat": "ism",
         "title": "Brave",
@@ -493,7 +493,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106861168508474/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Brave",
@@ -506,7 +506,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863662829747/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Battle: Los Angeles",
@@ -519,7 +519,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15034-LI.jpg",
         "fileFormat": "jpg",
         "title": "Battleship",
@@ -532,7 +532,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0718/UTV-15065-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Battle: Los Angeles",
@@ -546,7 +546,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15065-PI.jpg",
         "fileFormat": "jpg",
         "title": "Battle: Los Angeles",
@@ -559,7 +559,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828666135192/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Brave",
@@ -572,7 +572,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860928273398/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Battleship",
@@ -585,7 +585,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558263728740/pikselss.ism",
         "fileFormat": "ism",
         "title": "Battleship",
@@ -598,7 +598,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561723747780/pikselss.ism",
         "fileFormat": "ism",
         "title": "Battle: Los Angeles",
@@ -611,7 +611,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831225257649/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Battle: Los Angeles",
@@ -624,7 +624,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15011-LI.jpg",
         "fileFormat": "jpg",
         "title": "300: Rise of An Empire",
@@ -637,7 +637,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1436/UTV-BOX-15011-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "300: Rise of An Empire",
@@ -650,7 +650,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1053/UTV-15162-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "10,000 BC",
@@ -663,7 +663,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15019-LI.jpg",
         "fileFormat": "jpg",
         "title": "12 Years a Slave",
@@ -677,7 +677,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15000-PI.jpg",
         "fileFormat": "jpg",
         "title": "A Good Day To Die Hard",
@@ -690,7 +690,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1534/UTV-15000-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "A Good Day To Die Hard",
@@ -703,7 +703,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15000-LI.jpg",
         "fileFormat": "jpg",
         "title": "A Good Day To Die Hard",
@@ -716,7 +716,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1453/UTV-15033-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -729,7 +729,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15127-LI.jpg",
         "fileFormat": "jpg",
         "title": "2012",
@@ -742,7 +742,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1541/UTV-15001-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "About Time",
@@ -755,7 +755,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15001-LI.jpg",
         "fileFormat": "jpg",
         "title": "About Time",
@@ -768,7 +768,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1322/UTV-BOX-15006-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "22 Jump Street",
@@ -782,7 +782,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15006-PI.jpg",
         "fileFormat": "jpg",
         "title": "22 Jump Street",
@@ -795,7 +795,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15006-LI.jpg",
         "fileFormat": "jpg",
         "title": "22 Jump Street",
@@ -809,7 +809,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15019-PI.jpg",
         "fileFormat": "jpg",
         "title": "12 Years a Slave",
@@ -822,7 +822,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1704/UTV-BOX-15019-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "12 Years a Slave",
@@ -836,7 +836,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15033-PI.jpg",
         "fileFormat": "jpg",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -850,7 +850,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15127-PI.jpg",
         "fileFormat": "jpg",
         "title": "2012",
@@ -863,7 +863,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0930/UTV-15127-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "2012",
@@ -876,7 +876,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15033-LI.jpg",
         "fileFormat": "jpg",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -890,7 +890,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15163-PI.jpg",
         "fileFormat": "jpg",
         "title": "27 Dresses",
@@ -903,7 +903,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0932/UTV-15128-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "A Christmas Carol",
@@ -916,7 +916,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1049/UTV-15163-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "27 Dresses",
@@ -929,7 +929,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15163-LI.jpg",
         "fileFormat": "jpg",
         "title": "27 Dresses",
@@ -942,7 +942,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882010514535/piksel.mpd",
         "fileFormat": "mpd",
         "title": "300: Rise of An Empire",
@@ -955,7 +955,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848678882224/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "300: Rise of An Empire",
@@ -968,7 +968,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566245914468/pikselss.ism",
         "fileFormat": "ism",
         "title": "2012",
@@ -981,7 +981,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121848135301978/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "22 Jump Street",
@@ -994,7 +994,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106857689704594/piksel.mpd",
         "fileFormat": "mpd",
         "title": "A Good Day To Die Hard",
@@ -1007,7 +1007,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173558023923570/pikselss.ism",
         "fileFormat": "ism",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -1020,7 +1020,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555232851499/pikselss.ism",
         "fileFormat": "ism",
         "title": "A Good Day To Die Hard",
@@ -1033,7 +1033,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106860841843054/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -1046,7 +1046,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873056840198/piksel.mpd",
         "fileFormat": "mpd",
         "title": "10,000 BC",
@@ -1059,7 +1059,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836603233682/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "A Christmas Carol",
@@ -1072,7 +1072,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566320966671/pikselss.ism",
         "fileFormat": "ism",
         "title": "A Christmas Carol",
@@ -1085,7 +1085,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106857770254149/piksel.mpd",
         "fileFormat": "mpd",
         "title": "About Time",
@@ -1098,7 +1098,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839792292284/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "10,000 BC",
@@ -1111,7 +1111,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570172621416/pikselss.ism",
         "fileFormat": "ism",
         "title": "10,000 BC",
@@ -1124,7 +1124,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579170712705/pikselss.ism",
         "fileFormat": "ism",
         "title": "22 Jump Street",
@@ -1137,7 +1137,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839881931961/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "27 Dresses",
@@ -1150,7 +1150,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873133578707/piksel.mpd",
         "fileFormat": "mpd",
         "title": "27 Dresses",
@@ -1163,7 +1163,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570259391805/pikselss.ism",
         "fileFormat": "ism",
         "title": "27 Dresses",
@@ -1176,7 +1176,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121849496369339/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "12 Years a Slave",
@@ -1189,7 +1189,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173580455640168/pikselss.ism",
         "fileFormat": "ism",
         "title": "12 Years a Slave",
@@ -1203,7 +1203,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15011-PI.jpg",
         "fileFormat": "jpg",
         "title": "300: Rise of An Empire",
@@ -1216,7 +1216,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15162-LI.jpg",
         "fileFormat": "jpg",
         "title": "10,000 BC",
@@ -1230,7 +1230,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15162-PI.jpg",
         "fileFormat": "jpg",
         "title": "10,000 BC",
@@ -1244,7 +1244,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15001-PI.jpg",
         "fileFormat": "jpg",
         "title": "About Time",
@@ -1257,7 +1257,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15128-LI.jpg",
         "fileFormat": "jpg",
         "title": "A Christmas Carol",
@@ -1271,7 +1271,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15128-PI.jpg",
         "fileFormat": "jpg",
         "title": "A Christmas Carol",
@@ -1284,7 +1284,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836525779196/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "2012",
@@ -1297,7 +1297,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869386805104/piksel.mpd",
         "fileFormat": "mpd",
         "title": "2012",
@@ -1310,7 +1310,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173579008642425/pikselss.ism",
         "fileFormat": "ism",
         "title": "300: Rise of An Empire",
@@ -1323,7 +1323,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106881419417325/piksel.mpd",
         "fileFormat": "mpd",
         "title": "22 Jump Street",
@@ -1336,7 +1336,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869608616890/piksel.mpd",
         "fileFormat": "mpd",
         "title": "A Christmas Carol",
@@ -1349,7 +1349,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121824911979830/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "A Good Day To Die Hard",
@@ -1362,7 +1362,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825026944282/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "About Time",
@@ -1375,7 +1375,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121828445685712/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Abraham Lincoln: Vampire Hunter",
@@ -1388,7 +1388,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555469473992/pikselss.ism",
         "fileFormat": "ism",
         "title": "About Time",
@@ -1401,7 +1401,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106882619527754/piksel.mpd",
         "fileFormat": "mpd",
         "title": "12 Years a Slave",
@@ -1414,7 +1414,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/1022/UTV-15130-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Angels & Demons",
@@ -1428,7 +1428,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15164-PI.jpg",
         "fileFormat": "jpg",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -1441,7 +1441,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15164-LI.jpg",
         "fileFormat": "jpg",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -1455,7 +1455,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15061-PI.jpg",
         "fileFormat": "jpg",
         "title": "Battle Royale",
@@ -1468,7 +1468,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15061-LI.jpg",
         "fileFormat": "jpg",
         "title": "Battle Royale",
@@ -1481,7 +1481,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/09/0828/UTV-BOX-15038-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Anchorman 2: The Legend Continues",
@@ -1494,7 +1494,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/05/0903/UTV-15061-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Battle Royale",
@@ -1508,7 +1508,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15129-PI.jpg",
         "fileFormat": "jpg",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -1521,7 +1521,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0937/UTV-15129-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -1534,7 +1534,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15129-LI.jpg",
         "fileFormat": "jpg",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -1547,7 +1547,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0716/UTV-15064-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Arthur Christmas",
@@ -1561,7 +1561,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15199-PI.jpg",
         "fileFormat": "jpg",
         "title": "American Gangster",
@@ -1574,7 +1574,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15199-LI.jpg",
         "fileFormat": "jpg",
         "title": "American Gangster",
@@ -1587,7 +1587,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1356/UTV-15199-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "American Gangster",
@@ -1600,7 +1600,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/0806/UTV-15096-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Alice In Wonderland",
@@ -1613,7 +1613,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15096-LI.jpg",
         "fileFormat": "jpg",
         "title": "Alice In Wonderland",
@@ -1626,7 +1626,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/04/1544/UTV-15002-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "After Earth",
@@ -1639,7 +1639,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15002-LI.jpg",
         "fileFormat": "jpg",
         "title": "After Earth",
@@ -1652,7 +1652,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/9/7/landscape/UTV-15003-LI.jpg",
         "fileFormat": "jpg",
         "title": "Alan Partridge: Alpha Papa",
@@ -1666,7 +1666,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/9/7/portrait/UTV-15003-PI.jpg",
         "fileFormat": "jpg",
         "title": "Alan Partridge: Alpha Papa",
@@ -1679,7 +1679,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869773341327/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Angels & Demons",
@@ -1692,7 +1692,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/smooth-vod/IBC/UTV-15061/pvptest.ism",
         "fileFormat": "ism",
         "title": "Battle Royale",
@@ -1705,7 +1705,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836810848278/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -1718,7 +1718,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566566793775/pikselss.ism",
         "fileFormat": "ism",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -1731,7 +1731,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121836898817637/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Angels & Demons",
@@ -1744,7 +1744,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173566640799455/pikselss.ism",
         "fileFormat": "ism",
         "title": "Angels & Demons",
@@ -1757,7 +1757,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106873209844087/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -1770,7 +1770,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106863571445477/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Arthur Christmas",
@@ -1783,7 +1783,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121834275303248/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Alice In Wonderland",
@@ -1796,7 +1796,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173570431293898/pikselss.ism",
         "fileFormat": "ism",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -1809,7 +1809,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173561488070435/pikselss.ism",
         "fileFormat": "ism",
         "title": "Arthur Christmas",
@@ -1822,7 +1822,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106857844368431/piksel.mpd",
         "fileFormat": "mpd",
         "title": "After Earth",
@@ -1835,7 +1835,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825338935081/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Alan Partridge: Alpha Papa",
@@ -1848,7 +1848,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121825198575222/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "After Earth",
@@ -1860,7 +1860,7 @@
         "tags": [
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "2015/09/07/0652/ssManifest.ism",
         "title": "Alan Partridge: Alpha Papa",
         "contentRef": "sa-team:UTV-15003"
@@ -1871,7 +1871,7 @@
         "tags": [
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "2015/09/07/0652/Manifest.m3u8",
         "title": "Alan Partridge: Alpha Papa",
         "contentRef": "sa-team:UTV-15003"
@@ -1883,7 +1883,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106884132761407/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Anchorman 2: The Legend Continues",
@@ -1896,7 +1896,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173582002228884/pikselss.ism",
         "fileFormat": "ism",
         "title": "Anchorman 2: The Legend Continues",
@@ -1909,7 +1909,7 @@
           "trailerondemand",
           "showcase"
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn.pvp.piksel.com/trailers/2014/09/08/1050/UTV-15164-Trailer.mp4",
         "fileFormat": "mp4",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -1922,7 +1922,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15130-LI.jpg",
         "fileFormat": "jpg",
         "title": "Angels & Demons",
@@ -1936,7 +1936,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15130-PI.jpg",
         "fileFormat": "jpg",
         "title": "Angels & Demons",
@@ -1950,7 +1950,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-BOX-15038-PI.jpg",
         "fileFormat": "jpg",
         "title": "Anchorman 2: The Legend Continues",
@@ -1963,7 +1963,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-BOX-15038-LI.jpg",
         "fileFormat": "jpg",
         "title": "Anchorman 2: The Legend Continues",
@@ -1976,7 +1976,7 @@
           "landscape",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/landscape/UTV-15064-LI.jpg",
         "fileFormat": "jpg",
         "title": "Arthur Christmas",
@@ -1990,7 +1990,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15064-PI.jpg",
         "fileFormat": "jpg",
         "title": "Arthur Christmas",
@@ -2004,7 +2004,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15096-PI.jpg",
         "fileFormat": "jpg",
         "title": "Alice In Wonderland",
@@ -2018,7 +2018,7 @@
           "console:primary",
           "showcase"
         ],
-        "mediaType": "image",
+        "type": "image",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/images/2015/8/18/portrait/UTV-15002-PI.jpg",
         "fileFormat": "jpg",
         "title": "After Earth",
@@ -2031,7 +2031,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106869695478410/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Alvin and the Chipmunks: The Squeakquel",
@@ -2044,7 +2044,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173564061987959/pikselss.ism",
         "fileFormat": "ism",
         "title": "Alice In Wonderland",
@@ -2057,7 +2057,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121842959197652/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "American Gangster",
@@ -2070,7 +2070,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106875816223403/piksel.mpd",
         "fileFormat": "mpd",
         "title": "American Gangster",
@@ -2083,7 +2083,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173573518657745/pikselss.ism",
         "fileFormat": "ism",
         "title": "American Gangster",
@@ -2096,7 +2096,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121839974130555/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Aliens vs. Predator 2: Requiem",
@@ -2109,7 +2109,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106866244599926/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Alice In Wonderland",
@@ -2122,7 +2122,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121831135462024/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Arthur Christmas",
@@ -2135,7 +2135,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555706498614/pikselss.ism",
         "fileFormat": "ism",
         "title": "After Earth",
@@ -2148,7 +2148,7 @@
           "showcase",
           "SS        "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/ss-vod/2016/08/31/09/173555074011806/pikselss.ism",
         "fileFormat": "ism",
         "title": "Alan Partridge: Alpha Papa",
@@ -2161,7 +2161,7 @@
           "showcase",
           "DASH      "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/dash-vod/2016/08/30/14/106857918689335/piksel.mpd",
         "fileFormat": "mpd",
         "title": "Alan Partridge: Alpha Papa",
@@ -2174,7 +2174,7 @@
           "showcase",
           "HLS       "
         ],
-        "mediaType": "video",
+        "type": "video",
         "url": "http://cdn-origin-demo.digitalshowcase.piksel.com/hls-vod/2016/08/30/19/121851154874080/piksel.m3u8",
         "fileFormat": "m3u8",
         "title": "Anchorman 2: The Legend Continues",

--- a/test/fixtures/metadata-descriptor.json
+++ b/test/fixtures/metadata-descriptor.json
@@ -74,7 +74,7 @@
           "label": "title",
           "graphical": "url",
           "quickInfo": [
-            "mediaType",
+            "type",
             "fileFormat"
           ],
           "other": [
@@ -107,7 +107,7 @@
         },
         "singularName": "asset",
         "pluralName": "assets",
-        "grouping": "mediaType"
+        "grouping": "type"
       },
       "fields": {
         "ref": {
@@ -524,7 +524,7 @@
             }
           ]
         },
-        "mediaType": {
+        "type": {
           "description": "Asset media type",
           "type": "string",
           "primary": true,
@@ -569,8 +569,8 @@
             }
           ],
           "example": "video",
-          "fieldName": "mediaType",
-          "fieldNamePath": "mediaType",
+          "fieldName": "type",
+          "fieldNamePath": "type",
           "allowedValueMappings": {
             "application": "application",
             "audio": "audio",
@@ -585,29 +585,29 @@
             "name": "string"
           },
           "filteredBy": [
-            "withMediaType"
+            "withtype"
           ],
           "filters": [
             {
               "type": "with",
-              "label": "mediaType",
-              "description": "filter for mediaType",
-              "fieldNamePath": "mediaType",
-              "name": "withMediaType",
+              "label": "type",
+              "description": "filter for type",
+              "fieldNamePath": "type",
+              "name": "withtype",
               "and": true,
               "or": true,
               "valueType": "string"
             }
           ]
         },
-        "fullMediaType": {
-          "description": "The full media type for the asset. The value is determined dynamically based on mediaType and fileFormat",
+        "fullType": {
+          "description": "The full media type for the asset. The value is determined dynamically based on type and fileFormat",
           "type": "string",
           "sort": true,
           "primary": true,
           "example": "video/mp4",
-          "fieldName": "fullMediaType",
-          "fieldNamePath": "fullMediaType",
+          "fieldName": "fullType",
+          "fieldNamePath": "fullType",
           "typeInfo": {
             "desc": "string",
             "pattern": ".+",
@@ -2329,12 +2329,12 @@
           "or": true,
           "valueType": "version"
         },
-        "withMediaType": {
+        "withtype": {
           "type": "with",
-          "label": "mediaType",
-          "description": "filter for mediaType",
-          "fieldNamePath": "mediaType",
-          "name": "withMediaType",
+          "label": "type",
+          "description": "filter for type",
+          "fieldNamePath": "type",
+          "name": "withtype",
           "and": true,
           "or": true,
           "valueType": "string"
@@ -2405,7 +2405,7 @@
       "description": "Represents an asset of a content",
       "singularName": "asset",
       "serviceName": "metadata",
-      "parameterisedBy": "mediaType",
+      "parameterisedBy": "type",
       "pluralName": "assets",
       "hyphenatedPluralName": "assets",
       "displaySingularName": "asset",
@@ -5811,13 +5811,13 @@
             "relationship": "assets",
             "rules": [
               {
-                "mediaType": "image",
+                "type": "image",
                 "tags": [
                   "console:primary"
                 ]
               },
               {
-                "mediaType": "image"
+                "type": "image"
               }
             ],
             "value": "url"
@@ -7749,7 +7749,7 @@
             "ref",
             "name",
             "contentRef",
-            "mediaType",
+            "type",
             "url",
             "fileFormat",
             "title",

--- a/test/fixtures/metadata-descriptor.json
+++ b/test/fixtures/metadata-descriptor.json
@@ -600,14 +600,14 @@
             }
           ]
         },
-        "fullType": {
+        "fullMediaType": {
           "description": "The full media type for the asset. The value is determined dynamically based on type and fileFormat",
           "type": "string",
           "sort": true,
           "primary": true,
           "example": "video/mp4",
-          "fieldName": "fullType",
-          "fieldNamePath": "fullType",
+          "fieldName": "fullMediaType",
+          "fieldNamePath": "fullMediaType",
           "typeInfo": {
             "desc": "string",
             "pattern": ".+",


### PR DESCRIPTION
We have noticed in the old angular app images have gone missing, and we have seen that we are still using a deprecated prop, mediaType. This is a blanket find / replace to turn those into type, as mediaType has now been removed.