### PR TITLE
Cache descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ client
     // client.session); e.g. `session.isActive()`
 
     // Get a service::
-    client.service('metadata').then(service => {
+    client.serviceDescriptors('metadata').then(services => {
       // Get a resourceful endpoint (this is synchronous as the service passed
       // all the necessary data):
-      const contents = service.resourcefulEndpoint('contents');
+      const contents = services[0].resourcefulEndpoint('contents');
 
       contents
         .browse(
@@ -88,8 +88,8 @@ const client = new Client({
 });
 
 (async function init() {
-  const service = await client.service('metadata');
-  const contents = service.resourcefulEndpoint('contents');
+  const services = await client.serviceDescriptors('metadata');
+  const contents = services[0].resourcefulEndpoint('contents');
   const collection = await contents.browse(
     where()
       .fields('title', 'mediumSynopsis', 'duration', 'ref')

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ client
     // client.session); e.g. `session.isActive()`
 
     // Get a service::
-    client.serviceDescriptors('metadata').then(services => {
+    client.serviceDescriptors('metadata').then([metadata] => {
       // Get a resourceful endpoint (this is synchronous as the service passed
       // all the necessary data):
-      const contents = services[0].resourcefulEndpoint('contents');
+      const contents = metadata.resourcefulEndpoint('contents');
 
       contents
         .browse(

--- a/doc/tutorials/getting_started.md
+++ b/doc/tutorials/getting_started.md
@@ -27,10 +27,10 @@ client
     // client.session); e.g. `session.isActive()`
 
     // Get a service::
-    client.serviceDescriptors('metadata').then(services => {
+    client.serviceDescriptors('metadata').then([metadata] => {
       // Get a resourceful endpoint (this is synchronous as the service passed
       // all the necessary data):
-      const contents = services[0].resourcefulEndpoint('contents');
+      const contents = metadata.resourcefulEndpoint('contents');
 
       contents
         .browse(

--- a/doc/tutorials/getting_started.md
+++ b/doc/tutorials/getting_started.md
@@ -27,10 +27,10 @@ client
     // client.session); e.g. `session.isActive()`
 
     // Get a service::
-    client.service('metadata').then(service => {
+    client.serviceDescriptors('metadata').then(services => {
       // Get a resourceful endpoint (this is synchronous as the service passed
       // all the necessary data):
-      const contents = service.resourcefulEndpoint('contents');
+      const contents = services[0].resourcefulEndpoint('contents');
 
       contents
         .browse(
@@ -71,8 +71,8 @@ const client = new Client({
 (async function init() {
   await client.generate(bearerToken);
 
-  const service = await client.service('metadata');
-  const contents = service.resourcefulEndpoint('contents');
+  const services = await client.serviceDescriptors('metadata');
+  const contents = services[0].resourcefulEndpoint('contents');
   const collection = await contents.browse(
     where()
       .fields('title', 'mediumSynopsis', 'duration', 'ref')

--- a/lib/client.js
+++ b/lib/client.js
@@ -115,7 +115,7 @@ class Client {
   /**
    * Get a list of {@link ServiceDescriptor}s from the SDK cache, falling back to the service endpoint
    *
-   * @see {@link Registry#getServiceDescriptors}
+   * @see {@link Registry#getCachedServiceDescriptors}
    *
    * @param {...string} serviceNames - service names
    *

--- a/lib/client.js
+++ b/lib/client.js
@@ -74,10 +74,10 @@ import {
  */
 class Client {
   constructor({
-    directory, registryUri, identityUri, token, tenant
+    directory, registryUri, identityUri, token, tenant, enableCache
   }) {
     this.transport = new Transport();
-    this.registry = new Registry(this.transport, registryUri);
+    this.registry = new Registry(this.transport, registryUri, enableCache);
     this.session = new Session(this.transport, directory, this.registry, identityUri);
 
     if (tenant) this.setTenancy(tenant);

--- a/lib/client.js
+++ b/lib/client.js
@@ -100,9 +100,9 @@ class Client {
   }
 
   /**
-   * Get a list of {@link ServiceDescriptor}s from the {@link Registry}
+   * Get a list of {@link ServiceDescriptor}s from the service endpoint
    *
-   * @see {@link Registry#getServices}
+   * @see {@link Registry#getServiceDescriptors}
    *
    * @param {...string} serviceNames - service names
    *
@@ -111,6 +111,20 @@ class Client {
   serviceDescriptors(...serviceNames) {
     return this.registry.getServiceDescriptors(...serviceNames);
   }
+
+  /**
+   * Get a list of {@link ServiceDescriptor}s from the SDK cache, falling back to the service endpoint
+   *
+   * @see {@link Registry#getServiceDescriptors}
+   *
+   * @param {...string} serviceNames - service names
+   *
+   * @returns {Promise}
+   */
+  cachedServiceDescriptors(...serviceNames) {
+    return this.registry.getServiceDescriptors(...serviceNames, true);
+  }
+
 
   /**
    * Log an end user in with username and password credentials

--- a/lib/client.js
+++ b/lib/client.js
@@ -122,9 +122,8 @@ class Client {
    * @returns {Promise}
    */
   cachedServiceDescriptors(...serviceNames) {
-    return this.registry.getServiceDescriptors(...serviceNames, true);
+    return this.registry.getCachedServiceDescriptors(...serviceNames);
   }
-
 
   /**
    * Log an end user in with username and password credentials

--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,9 @@ import {
  * @property {string} directory - The directory to pass through to {@link Session}.
  * @property {string} registryUri - The registryUri to pass through to {@link Registry}.
  * @property {string?} identityUri - Optional identityUri to pass through to {@link Session}.
+ * @property {string?} token - Token to authenticate with.
+ * @property {string?} tenant - Tenant to initialize with.
+ * @property {boolean?} enableCache - Indicates wether to cache service descriptors in {@link Registry}.
  */
 
 /**

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -104,7 +104,8 @@ class ServiceDescriptor {
  *
  * @property {string} registryUri - URI of the Sequoia registry
  * e.g. https://registry-reference.sequoia.piksel.com
- * @property {Object[]} services - JSON data returned from the service's raw description
+ * @property {Object[]} services - Services available in the environment
+ * @property {Object} descriptors - JSON data returned from the service's raw description
  * e.g. https://metadata-reference.sequoia.piksel.com/descriptor/raw?owner=demo
  * @property {string} tenant - The name of the current tenancy being used e.g. 'demo'
  *
@@ -116,6 +117,7 @@ class Registry {
     this.transport = transport;
     this.registryUri = registryUri;
     this.services = [];
+    this.descriptors = {};
   }
 
   /**
@@ -165,17 +167,24 @@ class Registry {
    * (or at all)
    *
    * @param {string} serviceName - The name of the service to use e.g. 'metadata'
+   * @param {boolean} useCache - Indicate whether to use the cached descriptor if available
    *
    * @returns {Promise}
    */
-  getServiceDescriptor(serviceName) {
+  getServiceDescriptor(serviceName, useCache = false) {
     const service = this.services.find(item => item.name === serviceName);
 
     if (service) {
+      if (useCache && this.descriptors[serviceName]) {
+        console.log('using cache');
+        return Promise.resolve(new ServiceDescriptor(this.transport, this.descriptors[serviceName]));
+      }
       return this.transport.get(`${service.location}/descriptor/raw?owner=${this.tenant}`).then((json) => {
         json.location = service.location;
         json.owner = service.owner;
         json.tenant = this.tenant;
+
+        this.descriptors[serviceName] = json;
 
         return new ServiceDescriptor(this.transport, json);
       });
@@ -225,6 +234,8 @@ class Registry {
   refreshServices() {
     return this.transport.get(`${this.registryUri}/services/${this.tenant}`).then((json) => {
       this.services = json.services;
+      this.descriptors = {};
+      console.log('refreshing');
 
       return json;
     });

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -172,7 +172,6 @@ class Registry {
    */
   getCachedServiceDescriptor(serviceName) {
     const service = this.services.find(item => item.name === serviceName);
-    console.log('trying the cache');
 
     if (service && this.descriptors[serviceName]) {
       return Promise.resolve(new ServiceDescriptor(this.transport, this.descriptors[serviceName]));

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -101,6 +101,7 @@ class ServiceDescriptor {
  * @param {Transport} transport - Transport instance to use for fetching
  * @param {string} registryUri - URI of the Sequoia registry
  * e.g. https://registry-reference.sequoia.piksel.com
+ * @param {boolean} cache - Indicate wether or not to cache descriptors
  *
  * @property {string} registryUri - URI of the Sequoia registry
  * e.g. https://registry-reference.sequoia.piksel.com
@@ -113,11 +114,12 @@ class ServiceDescriptor {
  *
  */
 class Registry {
-  constructor(transport, registryUri) {
+  constructor(transport, registryUri, cache = false) {
     this.transport = transport;
     this.registryUri = registryUri;
     this.services = [];
     this.descriptors = {};
+    this.cache = cache;
   }
 
   /**
@@ -199,7 +201,9 @@ class Registry {
         json.owner = service.owner;
         json.tenant = this.tenant;
 
-        this.descriptors[serviceName] = json;
+        if (this.cache) {
+          this.descriptors[serviceName] = json;
+        }
 
         return new ServiceDescriptor(this.transport, json);
       });

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -161,24 +161,40 @@ class Registry {
   }
 
   /**
+   * Get ServiceDescriptor information from the SDK cache.
+   *
+   * Rejects the Promise if a service is requested that doesn't exist for this user
+   * (or at all), or if the descriptor is not in the cache
+   *
+   * @param {string} serviceName - The name of the service to use e.g. 'metadata'
+   *
+   * @returns {Promise}
+   */
+  getCachedServiceDescriptor(serviceName) {
+    const service = this.services.find(item => item.name === serviceName);
+    console.log('trying the cache');
+
+    if (service && this.descriptors[serviceName]) {
+      return Promise.resolve(new ServiceDescriptor(this.transport, this.descriptors[serviceName]));
+    }
+
+    return Promise.reject(new Error(`No service with name ${serviceName} is in the cache`));
+  }
+
+  /**
    * Get ServiceDescriptor information from the registry.
    *
    * Rejects the Promise if a service is requested that doesn't exist for this user
    * (or at all)
    *
    * @param {string} serviceName - The name of the service to use e.g. 'metadata'
-   * @param {boolean} useCache - Indicate whether to use the cached descriptor if available
    *
    * @returns {Promise}
    */
-  getServiceDescriptor(serviceName, useCache = false) {
+  getServiceDescriptor(serviceName) {
     const service = this.services.find(item => item.name === serviceName);
 
     if (service) {
-      if (useCache && this.descriptors[serviceName]) {
-        console.log('using cache');
-        return Promise.resolve(new ServiceDescriptor(this.transport, this.descriptors[serviceName]));
-      }
       return this.transport.get(`${service.location}/descriptor/raw?owner=${this.tenant}`).then((json) => {
         json.location = service.location;
         json.owner = service.owner;
@@ -211,7 +227,7 @@ class Registry {
   }
 
   /**
-   * Get multiple ServiceDescriptor information from the registry.
+   * Get multiple ServiceDescriptor information from the services endpoints.
    *
    * Rejects the Promise if a service is requested that doesn't exist for this user
    * (or at all)
@@ -227,6 +243,24 @@ class Registry {
   }
 
   /**
+   * Get multiple ServiceDescriptor information from the SDK cache, falling back to the services endpoint.
+   *
+   * Rejects the Promise if a service is requested that doesn't exist for this user
+   * (or at all)
+   *
+   * @param {...string} serviceName - The name of the service to use e.g. 'metadata'
+   *
+   * @returns {Promise}
+   */
+  getCachedServiceDescriptors(...serviceName) {
+    const services = serviceName.length ? serviceName : this.services.map(s => s.name);
+
+    return Promise.all(services.map(s => this.getCachedServiceDescriptor(s)
+      .catch(() => this.getServiceDescriptor(s))));
+  }
+
+
+  /**
    * Refresh services that are cached inside the SDK.
    *
    * @returns {Promise}
@@ -235,7 +269,6 @@ class Registry {
     return this.transport.get(`${this.registryUri}/services/${this.tenant}`).then((json) => {
       this.services = json.services;
       this.descriptors = {};
-      console.log('refreshing');
 
       return json;
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Sequoia client SDK for Javascript",
   "main": "dist/web/sequoia-client.js",
   "scripts": {

--- a/test/spec/client.js
+++ b/test/spec/client.js
@@ -178,6 +178,45 @@ describe('Client', () => {
       });
     });
 
+    describe('cachedServiceDescriptors', () => {
+      beforeEach(() => {
+        client.registry.descriptors = {
+          metadata: { name: 'metadata' },
+          payment: { name: 'payment' }
+        };
+        jest.spyOn(client.registry, 'getCachedServiceDescriptors');
+      });
+
+      it('should resolve with services from the cache', async () => {
+        await expect(client.cachedServiceDescriptors('metadata')).resolves.toEqual([
+          {
+            asymmetricMatch: actual => actual instanceof ServiceDescriptor && actual.data.name === 'metadata'
+          }
+        ]);
+
+        expect(client.registry.getCachedServiceDescriptors).toHaveBeenCalledWith('metadata');
+      });
+
+      it('should resolve with multiple services from the cache', async () => {
+        await expect(client.cachedServiceDescriptors('metadata', 'payment')).resolves.toEqual([
+          {
+            asymmetricMatch: actual => actual instanceof ServiceDescriptor && actual.data.name === 'metadata'
+          },
+          {
+            asymmetricMatch: actual => actual instanceof ServiceDescriptor && actual.data.name === 'payment'
+          }
+        ]);
+
+        expect(client.registry.getCachedServiceDescriptors).toHaveBeenCalledWith('metadata', 'payment');
+      });
+
+      it("should reject when the service doesn't exist in the registry", async () => {
+        const serviceName = 'thisdoesnotexist';
+
+        return expect(client.cachedServiceDescriptors(serviceName)).rejects.toEqual(new Error('No service with name thisdoesnotexist exists'));
+      });
+    });
+
     describe('onExpiryWarning', () => {
       it('should call onExpiryWarning when token about to expire', () => {
         const callback = jest.fn();

--- a/test/spec/client.js
+++ b/test/spec/client.js
@@ -66,7 +66,18 @@ describe('Client', () => {
       expect(client.transport).toBeDefined();
       expect(client.registry).toEqual(expect.any(Registry));
       expect(client.registry.registryUri).toEqual(registryUri);
+      expect(client.registry.cache).toBe(false);
       expect(client.session.registry).toEqual(expect.any(Registry));
+    });
+
+    it('should pass the enableCache value to registry', () => {
+      client = new Client({
+        directory,
+        registryUri,
+        identityUri,
+        enableCache: true
+      });
+      expect(client.registry.cache).toBe(true);
     });
 
     it('should accept an optional `identityUri`', () => {

--- a/test/spec/registry.js
+++ b/test/spec/registry.js
@@ -21,7 +21,7 @@ describe('Registry', () => {
     fetchMock.mock(servicesUri, servicesFixture)
       .mock(descriptorUri, metadataDescriptorFixture)
       .mock(gatewayDescriptorUri, gatewayDescriptorFixture);
-    registry = new Registry(transport, registryUri);
+    registry = new Registry(transport, registryUri, true);
   });
 
   afterEach(fetchMock.restore);
@@ -120,6 +120,13 @@ describe('Registry', () => {
       expect(registry.descriptors).toEqual({});
       await registry.getServiceDescriptor('metadata');
       expect(registry.descriptors.metadata).toEqual(expect.objectContaining({ name: 'metadata' }));
+    });
+
+    it('should not add the data to the descriptors property if the cache property is false', async () => {
+      expect(registry.descriptors).toEqual({});
+      registry.cache = false;
+      await registry.getServiceDescriptor('metadata');
+      expect(registry.descriptors.metadata).not.toEqual(expect.objectContaining({ name: 'metadata' }));
     });
   });
 

--- a/test/spec/registry.js
+++ b/test/spec/registry.js
@@ -82,7 +82,9 @@ describe('Registry', () => {
   describe('getServiceDescriptor', () => {
     beforeEach(async () => registry.fetch(testTenant));
 
-    it('should reject when it can\'t find a service with the supplied name', async () => expect(registry.getServiceDescriptor('thisdoesnotexist')).rejects.toThrow());
+    it('should reject when it can\'t find a service with the supplied name', async () => {
+      await expect(registry.getServiceDescriptor('thisdoesnotexist')).rejects.toThrow();
+    });
 
     it('should perform a GET on the services descriptor/raw endpoint', async () => {
       await registry.getServiceDescriptor('metadata');
@@ -129,7 +131,9 @@ describe('Registry', () => {
       await expect(registry.getCachedServiceDescriptor('metadata')).resolves.toEqual(expect.objectContaining({ data: { name: 'foobar' } }));
     });
 
-    it('should reject when it can\'t find a service with the supplied name', async () => expect(registry.getServiceDescriptor('thisdoesnotexist')).rejects.toThrow());
+    it('should reject when it can\'t find a service with the supplied name', async () => {
+      await expect(registry.getServiceDescriptor('thisdoesnotexist')).rejects.toThrow();
+    });
 
     it('should reject when it can\'t find a descriptor in the cache', async () => {
       expect(registry.descriptors).toEqual({});


### PR DESCRIPTION
**This pull request enables the caching of service descriptors by the SDK.**

The cached descriptors can be used by calling `client.cachedServiceDescriptors`. If a descriptor is not in the cache, it falls back to a fetch request.

Cached descriptors are cleared when `registry.refreshServices` is called, which is in turn called whenever a tenant is set.

I have given this a minor version bump, as it is new functionality, but not breaking.

This addition was largely driven by our application which makes heavy use of descriptor config and regularly fetches the descriptors. Using this version of the SDK has resulted in a noticeable improvement of the apps responsiveness.

