### PR TITLE
Better error message for error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.7.1
+## 1.8.0
 
 * Proper error message returned when a request is failed (taken from response.body.message)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.1
+
+* Proper error message returned when a request is failed (taken from response.body.message)
+
 ## 1.7.0
 
 * Added ability to pass an array of records to ResourcefulEndpoint.newResourceCollection()

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -50,9 +50,11 @@ class Transport {
   fetchWithDefaults(url, options = {}) {
     return fetch(url, Object.assign({}, this.defaults, options)).then((response) => {
       if (!response.ok) {
-        const error = new Error(response.statusText);
-        error.response = response;
-        throw error;
+        return response.json().then((responseBody) => {
+          const error = new Error(responseBody.message);
+          error.response = response;
+          throw error;
+        });
       }
 
       if (response.status === 204) {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -50,11 +50,18 @@ class Transport {
   fetchWithDefaults(url, options = {}) {
     return fetch(url, Object.assign({}, this.defaults, options)).then((response) => {
       if (!response.ok) {
-        return response.json().then((responseBody) => {
-          const error = new Error(responseBody.message);
-          error.response = response;
-          throw error;
-        });
+        return response.json().then(
+          (responseBody) => {
+            const error = new Error(responseBody.message);
+            error.response = response;
+            throw error;
+          },
+          () => {
+            const error = new Error(response.statusText);
+            error.response = response;
+            throw error;
+          }
+        );
       }
 
       if (response.status === 204) {

--- a/test/spec/transport.js
+++ b/test/spec/transport.js
@@ -51,6 +51,22 @@ describe('transport', () => {
       });
     });
 
+    it('should reject with statusText when response.json() promise is rejected', async () => {
+      const response = new Response();
+      response.json = () => Promise.reject();
+      response.status = 500;
+      response.ok = false;
+      response.statusText = 'status text';
+
+      fetchMock.mock('/', response);
+
+      return expect(transport.get('/')).rejects.toEqual({
+        asymmetricMatch: actual => actual.response.ok === false
+          && actual instanceof Error
+          && actual.message === 'status text'
+      });
+    });
+
     it('should reject on non-JSON responses', async () => {
       fetchMock.mock('/', { body: '<html>this is not json</html>' });
 

--- a/test/spec/transport.js
+++ b/test/spec/transport.js
@@ -39,10 +39,15 @@ describe('transport', () => {
     });
 
     it('should reject with HTTP errors', async () => {
-      fetchMock.mock('/', 500);
+      fetchMock.mock('/', {
+        status: 500,
+        body: { message: 'test message' }
+      });
 
       return expect(transport.get('/')).rejects.toEqual({
-        asymmetricMatch: actual => actual.response.ok === false && actual instanceof Error
+        asymmetricMatch: actual => actual.response.ok === false
+          && actual instanceof Error
+          && actual.message === 'test message'
       });
     });
 


### PR DESCRIPTION
The error message in the `Error` object returned by the rejected promise when a response is failed, is now got from the body of the response (`response.body.message`).