### PR TITLE
Handle through relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add `encodeUri` configuration option.  Will cause the client to automatically encode request urls it generates.
+* Add addRelatedThroughFields to the Query class, update logic in resourceful_endpoint browse method to use this method to fetch additional fields required on included through relationships to support their use with graphical display descriptors for example.
 
 ## 1.9.0
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -174,8 +174,8 @@ class Query {
    * relationships - this makes it so that the end user shouldn't know or care that
    * through relationships exist.
    *
-   * @param {relationsips} relationships - The relationship definitions that may
-   * require the addition of fields to support the graphical display of through relationship
+   * @param {relationships} relationships - The relationship definitions that may
+   * require the addition of fields to support the graphical display of a through relationship
    *
    * @returns {Query}
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,3 +1,4 @@
+import queryString from 'qs';
 import Predications from './predications';
 
 /**
@@ -165,6 +166,40 @@ class Query {
    */
   orderBy(fieldName) {
     this.sort = fieldName;
+    return this;
+  }
+
+  /**
+   * Look through the relationships of a criteria, and include fields from through
+   * relationships - this makes it so that the end user shouldn't know or care that
+   * through relationships exist.
+   *
+   * @param {relationsips} relationships - The relationship definitions that may
+   * require the addition of fields to support the graphical display of through relationship
+   *
+   * @returns {Query}
+
+   */
+  addRelatedThroughFields(relationships) {
+    const parsedQueryString = queryString.parse(this.query, { ignoreQueryPrefix: true, allowDots: true });
+    const includes = Object.keys(parsedQueryString).includes('include') ? parsedQueryString.include.split(',') : [];
+    let fields = Object.keys(parsedQueryString).includes('fields') ? parsedQueryString.fields.split(',') : [];
+
+    const filteredIncludes = includes
+      .map((include) => {
+        const { through } = relationships[include] || '';
+        const throughRelationship = relationships[through] || {};
+
+        return throughRelationship.fieldNamePath || false;
+      })
+      .filter(fieldNamePath => fieldNamePath);
+
+
+    fields = filteredIncludes.length ? fields.concat(filteredIncludes) : fields;
+
+    parsedQueryString.fields = fields.length ? fields.join(',') : undefined;
+
+    this.query = queryString.stringify(parsedQueryString, { encode: false });
     return this;
   }
 

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -85,9 +85,58 @@ class ResourceCollection {
               // disparate content where links come back for every item in the list
               // (e.g. metatdata/contents -> linked assets).
               // However, some resourcefuls have links without this explicitly set
-              // e.g. payment/subscriptions -> linked customers
+              // e.g. relationships like credits/relatedMaterials.assets that have
+              // a through, or payment/subscriptions -> linked customers
               if (item[linkByRefName]) {
                 return item[linkByRefName] === resource.ref;
+              }
+
+              // Handling relationships that have a through
+              const through = this.resourcefulEndpoint &&
+                this.resourcefulEndpoint.resourceful &&
+                this.resourcefulEndpoint.resourceful.relationships &&
+                this.resourcefulEndpoint.resourceful.relationships[link] &&
+                this.resourcefulEndpoint.resourceful.relationships[link].through;
+
+              if (through) {
+                let throughRef;
+
+                // Through can be a plural when we need it not to be - this is brittle
+                // What happens if we have a singular through that ends in s? What happens
+                // with people / person?
+                if (through.substring(through.length - 1) === 's') {
+                  throughRef = through.substring(0, through.length - 1);
+                } else {
+                  throughRef = through;
+                }
+
+                throughRef = `${throughRef}Refs`;
+
+                const throughItems = resource[throughRef];
+
+                const throughRelationship = this.resourcefulEndpoint.resourceful.relationships[through];
+
+                let resourceType = throughRelationship && throughRelationship.resourceType;
+
+                if (resourceType && resourceType.substring(resourceType.length - 1) === 's') {
+                  resourceType = resourceType.substring(0, resourceType.length - 1);
+                }
+
+                const linkRef = resourceType && `${resourceType}Ref`;
+
+                if (throughItems) {
+                  if (Array.isArray(throughItems)) {
+                    return throughItems.some((throughItem) => {
+                      return throughItem === item[linkRef];
+                    });
+                  }
+
+                  const throughItem = throughItems;
+
+                  return throughItem === item[linkRef];
+                }
+
+                return false;
               }
 
               /* istanbul ignore next */

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -84,6 +84,7 @@ class ResourceCollection {
               // that are directly linked (this helps when `browsing()` a list of
               // disparate content where links come back for every item in the list
               // (e.g. metatdata/contents -> linked assets).
+
               // However, some resourcefuls have links without this explicitly set
               // e.g. relationships like credits/relatedMaterials.assets that have
               // a through, or payment/subscriptions -> linked customers
@@ -98,49 +99,47 @@ class ResourceCollection {
                 this.resourcefulEndpoint.resourceful.relationships[link] &&
                 this.resourcefulEndpoint.resourceful.relationships[link].through;
 
-              if (through) {
-                let throughRef;
+              // if we do not have a through, we are handling payment/customers
+              // and we don't want to filter anything out
+              if (!through) return true;
 
-                // Through can be a plural when we need it not to be - this is brittle
-                // What happens if we have a singular through that ends in s? What happens
-                // with people / person?
-                if (through.substring(through.length - 1) === 's') {
-                  throughRef = through.substring(0, through.length - 1);
-                } else {
-                  throughRef = through;
-                }
-
-                throughRef = `${throughRef}Refs`;
-
-                const throughItems = resource[throughRef];
-
-                const throughRelationship = this.resourcefulEndpoint.resourceful.relationships[through];
-
-                let resourceType = throughRelationship && throughRelationship.resourceType;
-
-                if (resourceType && resourceType.substring(resourceType.length - 1) === 's') {
-                  resourceType = resourceType.substring(0, resourceType.length - 1);
-                }
-
-                const linkRef = resourceType && `${resourceType}Ref`;
-
-                if (throughItems) {
-                  if (Array.isArray(throughItems)) {
-                    return throughItems.some((throughItem) => {
-                      return throughItem === item[linkRef];
-                    });
-                  }
-
-                  const throughItem = throughItems;
-
-                  return throughItem === item[linkRef];
-                }
-
-                return false;
+              let throughRef;
+              // Through can be a plural when it needs to be singular - this is brittle
+              // What happens if we have a singular through that ends in s? What happens
+              // with people / person?
+              if (through.substring(through.length - 1) === 's') {
+                throughRef = through.substring(0, through.length - 1);
+              } else {
+                throughRef = through;
               }
 
-              /* istanbul ignore next */
-              return true;
+              throughRef = `${throughRef}Refs`;
+
+              const throughItems = resource[throughRef];
+
+              const throughRelationship = this.resourcefulEndpoint.resourceful.relationships[through];
+
+              let resourceType = throughRelationship && throughRelationship.resourceType;
+
+              if (resourceType && resourceType.substring(resourceType.length - 1) === 's') {
+                resourceType = resourceType.substring(0, resourceType.length - 1);
+              }
+
+              const linkRef = resourceType && `${resourceType}Ref`;
+
+              if (throughItems) {
+                if (Array.isArray(throughItems)) {
+                  return throughItems.some((throughItem) => {
+                    return throughItem === item[linkRef];
+                  });
+                }
+
+                const throughItem = throughItems;
+
+                return throughItem === item[linkRef];
+              }
+
+              return false;
             });
           });
         }

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -1,4 +1,5 @@
 import Resource from './resource';
+import Client from './client';
 
 export const NO_RESOURCEFUL_ENDPOINT_ERROR = `
 No resourceful endpoint tied to this resource collection.
@@ -32,14 +33,14 @@ class ResourceCollection {
   /**
    * @param {Object} rawData - Raw JSON response from the Sequoia endpoint
    * @param {string} initialCriteria - the initial filter criteria used when requesting from this endpoint
-   * @param {ResourcefulEndpoint} resourcefulEndpoint - The {@link ResourcefulEdnpoint} that created this ResourceCollection
+   * @param {ResourcefulEndpoint} resourcefulEndpoint - The {@link ResourcefulEndpoint} that created this ResourceCollection
    *
    * @returns {Resource}
    */
   constructor(rawData, initialCriteria, resourcefulEndpoint) {
     /** @property {string} - the initial filter criteria used when requesting from this endpoint */
     this.initialCriteria = initialCriteria;
-    /** @property {ResourcefulEndpoint} - The {@link ResourcefulEdnpoint} that created this ResourceCollection */
+    /** @property {ResourcefulEndpoint} - The {@link ResourcefulEndpoint} that created this ResourceCollection */
     this.resourcefulEndpoint = resourcefulEndpoint;
     /** @property {Resource[]} - Array of {@link Resource} objects */
     this.collection = [];
@@ -92,51 +93,26 @@ class ResourceCollection {
                 return item[linkByRefName] === resource.ref;
               }
 
-              // Handling relationships that have a through
-              const through = this.resourcefulEndpoint
+              const relationship = this.resourcefulEndpoint
                 && this.resourcefulEndpoint.resourceful
                 && this.resourcefulEndpoint.resourceful.relationships
-                && this.resourcefulEndpoint.resourceful.relationships[link]
-                && this.resourcefulEndpoint.resourceful.relationships[link].through;
+                && this.resourcefulEndpoint.resourceful.relationships[link];
+
+              // Handling relationships that have a through
+              const { through, filterName } = relationship;
 
               // if we do not have a through, we are handling payment/customers
               // and we don't want to filter anything out
               if (!through) return true;
 
               const throughRelationship = this.resourcefulEndpoint.resourceful.relationships[through];
+              const { resourceType, fieldNamePath } = throughRelationship;
+              const throughField = resource[fieldNamePath];
+              const resultFieldNamePath = this.resourcefulEndpoint.resourceful.filters
+                && this.resourcefulEndpoint.resourceful.filters[filterName]
+                && this.resourcefulEndpoint.resourceful.filters[filterName].fieldNamePath;
 
-              let resourceType = throughRelationship && throughRelationship.resourceType;
-
-              if (resourceType && resourceType.substring(resourceType.length - 1) === 's') {
-                resourceType = resourceType.substring(0, resourceType.length - 1);
-              }
-
-              const linkRef = resourceType && `${resourceType}Ref`;
-
-              let throughRef;
-
-              // Through can be a plural when it needs to be singular - this is brittle
-              // What happens if we have a singular through that ends in s? What happens
-              // with people / person?
-              if (through.substring(through.length - 1) === 's') {
-                throughRef = through.substring(0, through.length - 1);
-              } else {
-                throughRef = through;
-              }
-
-              throughRef = `${throughRef}Refs`;
-
-              const throughItems = resource[throughRef];
-
-              if (throughItems) {
-                if (Array.isArray(throughItems)) {
-                  return throughItems.some((throughItem) => throughItem === item[linkRef]);
-                }
-
-                return throughItems === item[linkRef];
-              }
-
-              return false;
+              return (throughField && throughField.some(field => field === item[resultFieldNamePath]));
             });
           });
         }

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -68,12 +68,10 @@ class ResourceCollection {
    */
   setData(rawData) {
     this.rawData = rawData;
-
     // Without a descriptor, we don't know truly know what to pick out
     if (this.resourcefulEndpoint && this.rawData && this.rawData[this.resourcefulEndpoint.pluralName]) {
       this.collection = this.rawData[this.resourcefulEndpoint.pluralName].map((content) => {
         const resource = Object.assign({}, content); // Copy
-
         if (this.rawData.linked) {
           const linkByRefName = `${this.resourcefulEndpoint.singularName}Ref`;
           resource.linked = {};
@@ -95,22 +93,20 @@ class ResourceCollection {
               const relationship = this.resourcefulEndpoint
                 && this.resourcefulEndpoint.resourceful
                 && this.resourcefulEndpoint.resourceful.relationships
-                && this.resourcefulEndpoint.resourceful.relationships[link];
+                && this.resourcefulEndpoint.resourceful.relationships[link] || {};
 
-              // Handling relationships that have a through
               const { through, filterName } = relationship;
-
               // if we do not have a through, we are handling payment/customers
               // and we don't want to filter anything out
               if (!through) return true;
 
               const { fieldNamePath } = this.resourcefulEndpoint.resourceful.relationships[through];
-              const throughField = resource[fieldNamePath];
+              const throughFields = resource[fieldNamePath] || [];
               const filteredFieldNamePath = this.resourcefulEndpoint.resourceful.filters
                 && this.resourcefulEndpoint.resourceful.filters[filterName]
                 && this.resourcefulEndpoint.resourceful.filters[filterName].fieldNamePath;
 
-              return (throughField && throughField.some(field => field === item[filteredFieldNamePath]));
+              return throughFields.some(field => field === item[filteredFieldNamePath]);
             });
           });
         }

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -93,17 +93,28 @@ class ResourceCollection {
               }
 
               // Handling relationships that have a through
-              const through = this.resourcefulEndpoint &&
-                this.resourcefulEndpoint.resourceful &&
-                this.resourcefulEndpoint.resourceful.relationships &&
-                this.resourcefulEndpoint.resourceful.relationships[link] &&
-                this.resourcefulEndpoint.resourceful.relationships[link].through;
+              const through = this.resourcefulEndpoint
+                && this.resourcefulEndpoint.resourceful
+                && this.resourcefulEndpoint.resourceful.relationships
+                && this.resourcefulEndpoint.resourceful.relationships[link]
+                && this.resourcefulEndpoint.resourceful.relationships[link].through;
 
               // if we do not have a through, we are handling payment/customers
               // and we don't want to filter anything out
               if (!through) return true;
 
+              const throughRelationship = this.resourcefulEndpoint.resourceful.relationships[through];
+
+              let resourceType = throughRelationship && throughRelationship.resourceType;
+
+              if (resourceType && resourceType.substring(resourceType.length - 1) === 's') {
+                resourceType = resourceType.substring(0, resourceType.length - 1);
+              }
+
+              const linkRef = resourceType && `${resourceType}Ref`;
+
               let throughRef;
+
               // Through can be a plural when it needs to be singular - this is brittle
               // What happens if we have a singular through that ends in s? What happens
               // with people / person?
@@ -117,26 +128,12 @@ class ResourceCollection {
 
               const throughItems = resource[throughRef];
 
-              const throughRelationship = this.resourcefulEndpoint.resourceful.relationships[through];
-
-              let resourceType = throughRelationship && throughRelationship.resourceType;
-
-              if (resourceType && resourceType.substring(resourceType.length - 1) === 's') {
-                resourceType = resourceType.substring(0, resourceType.length - 1);
-              }
-
-              const linkRef = resourceType && `${resourceType}Ref`;
-
               if (throughItems) {
                 if (Array.isArray(throughItems)) {
-                  return throughItems.some((throughItem) => {
-                    return throughItem === item[linkRef];
-                  });
+                  return throughItems.some((throughItem) => throughItem === item[linkRef]);
                 }
 
-                const throughItem = throughItems;
-
-                return throughItem === item[linkRef];
+                return throughItems === item[linkRef];
               }
 
               return false;

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -84,7 +84,7 @@ class ResourceCollection {
               // If a `linkByRefName` exists on this link, filter only those
               // that are directly linked (this helps when `browsing()` a list of
               // disparate content where links come back for every item in the list
-              // (e.g. metatdata/contents -> linked assets).
+              // (e.g. metadata/contents -> linked assets).
 
               // However, some resourcefuls have links without this explicitly set
               // e.g. relationships like credits/relatedMaterials.assets that have

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -1,5 +1,4 @@
 import Resource from './resource';
-import Client from './client';
 
 export const NO_RESOURCEFUL_ENDPOINT_ERROR = `
 No resourceful endpoint tied to this resource collection.
@@ -105,7 +104,7 @@ class ResourceCollection {
               // and we don't want to filter anything out
               if (!through) return true;
 
-              const { resourceType, fieldNamePath } = this.resourcefulEndpoint.resourceful.relationships[through];
+              const { fieldNamePath } = this.resourcefulEndpoint.resourceful.relationships[through];
               const throughField = resource[fieldNamePath];
               const filteredFieldNamePath = this.resourcefulEndpoint.resourceful.filters
                 && this.resourcefulEndpoint.resourceful.filters[filterName]

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -105,14 +105,13 @@ class ResourceCollection {
               // and we don't want to filter anything out
               if (!through) return true;
 
-              const throughRelationship = this.resourcefulEndpoint.resourceful.relationships[through];
-              const { resourceType, fieldNamePath } = throughRelationship;
+              const { resourceType, fieldNamePath } = this.resourcefulEndpoint.resourceful.relationships[through];
               const throughField = resource[fieldNamePath];
-              const resultFieldNamePath = this.resourcefulEndpoint.resourceful.filters
+              const filteredFieldNamePath = this.resourcefulEndpoint.resourceful.filters
                 && this.resourcefulEndpoint.resourceful.filters[filterName]
                 && this.resourcefulEndpoint.resourceful.filters[filterName].fieldNamePath;
 
-              return (throughField && throughField.some(field => field === item[resultFieldNamePath]));
+              return (throughField && throughField.some(field => field === item[filteredFieldNamePath]));
             });
           });
         }

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -90,10 +90,10 @@ class ResourceCollection {
                 return item[linkByRefName] === resource.ref;
               }
 
-              const relationship = this.resourcefulEndpoint
+              const relationship = (this.resourcefulEndpoint
                 && this.resourcefulEndpoint.resourceful
                 && this.resourcefulEndpoint.resourceful.relationships
-                && this.resourcefulEndpoint.resourceful.relationships[link] || {};
+                && this.resourcefulEndpoint.resourceful.relationships[link]) || {};
 
               const { through, filterName } = relationship;
               // if we do not have a through, we are handling payment/customers

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -212,7 +212,32 @@ class ResourcefulEndpoint {
    * @returns {Promise} - A {@link ResourceCollection}
    */
   browse(criteria, options) {
-    return this.transport.get(this.endPointUrl(null, criteria), options).then(json => new ResourceCollection(json, criteria, this));
+    const { query } = criteria;
+    const params = query.split('&');
+    const includesString = params.find(param => param.startsWith('include=')) || '';
+    const includes = includesString.replace('include=', '').split(',') || [];
+    let fields = params.find(param => param.startsWith('fields=')) || '';
+
+    const filteredIncludes = includes
+      .map((include) => {
+        const relationship = this.resourceful.relationships[include];
+        const { through } = relationship;
+        const { fieldNamePath } = this.resourceful.relationships[through] || {};
+        return fieldNamePath;
+      })
+      .filter(fieldNamePath => fieldNamePath);
+      fields += `,${filteredIncludes.join(',')}`;
+    
+    const newQuery = criteria.query
+      .split('&')
+      .map(queryItem => queryItem.startsWith('fields=') ? fields : queryItem)
+      .join('&');
+
+    criteria.query = newQuery;
+
+    return this.transport.get(this.endPointUrl(null, criteria), options).then((json) => {
+      return new ResourceCollection(json, criteria, this);
+    });
   }
 
   /**
@@ -522,6 +547,7 @@ class ResourcefulEndpoint {
    * @returns {string}
    */
   criteriaToQuery(criteria) {
+    console.log(criteria);
     let query = `?owner=${this.owner}`;
 
     if (typeof criteria === 'string') {

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -248,7 +248,7 @@ class ResourcefulEndpoint {
       .map((include) => {
         const { through } = this.resourceful.relationships[include] || {};
 
-        if (!through) return;
+        if (!through) return false;
 
         const throughRelationship = this.resourceful.relationships[through] || {};
 

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -212,9 +212,9 @@ class ResourcefulEndpoint {
    * @returns {Promise} - A {@link ResourceCollection}
    */
   browse(criteria, options) {
-    return this.transport.get(this.endPointUrl(null, this.getRelatedThroughFields(criteria)), options).then((json) => {
-      return new ResourceCollection(json, criteria, this);
-    });
+    return this.transport
+      .get(this.endPointUrl(null, this.getRelatedThroughFields(criteria)), options)
+      .then(json => new ResourceCollection(json, criteria, this));
   }
 
   getRelatedThroughFields(criteria) {
@@ -232,7 +232,7 @@ class ResourcefulEndpoint {
         return fieldNamePath;
       })
       .filter(fieldNamePath => fieldNamePath);
-    
+
     const newQuery = criteria.query
       .split('&')
       .map(queryItem => queryItem.startsWith('fields=') ? fields.concat(filteredIncludes).join(',') : queryItem)

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -217,28 +217,58 @@ class ResourcefulEndpoint {
       .then(json => new ResourceCollection(json, criteria, this));
   }
 
+  /**
+   * Private
+   * Look through the relationships of a criteria, and include fields from through
+   * relationships - this makes it so that the end user shouldn't know or care that
+   * through relationships exist.
+   *
+   * @param {(string|Query)} criteria - A query string to append to the request
+   *
+   * @returns {(Query)} criteria - A qquery with additional includes if needed
+
+   */
   getRelatedThroughFields(criteria) {
     if (!criteria || !criteria.query) return criteria;
-
     const query = criteria.query || '';
     const params = query.split('&');
-    const includesString = params.find(param => param.startsWith('include=')) || '';
-    const includes = includesString.replace('include=', '').split(',') || [];
-    const fields = (params.find(param => param.startsWith('fields=')) || '').split(',');
+    const includes = params.find(param => param.startsWith('include=') || '')
+      .replace('include=', '')
+      .split(',');
+
+    let fields = params.find(param => param.startsWith('fields=')) || '';
+
+    if (fields) {
+      fields = fields.split(',');
+    } else {
+      fields = [];
+    }
 
     const filteredIncludes = includes
       .map((include) => {
         const { through } = this.resourceful.relationships[include] || {};
-        const { fieldNamePath } = this.resourceful.relationships[through] || {};
 
-        return fieldNamePath;
+        if (!through) return;
+
+        const throughRelationship = this.resourceful.relationships[through] || {};
+
+        // eslint-disable-next-line consistent-return
+        return throughRelationship.fieldNamePath;
       })
       .filter(fieldNamePath => fieldNamePath);
 
-    const newQuery = criteria.query
+    if (!filteredIncludes.length) {
+      return criteria;
+    }
+
+    let newQuery = filteredIncludes && criteria.query
       .split('&')
       .map(queryItem => queryItem.startsWith('fields=') ? fields.concat(filteredIncludes).join(',') : queryItem)
       .join('&');
+
+    if (!newQuery.includes('fields=')) {
+      newQuery = newQuery.concat('&', `fields=${filteredIncludes.join(',')}`);
+    }
 
     criteria.query = newQuery;
 

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -218,7 +218,9 @@ class ResourcefulEndpoint {
   }
 
   getRelatedThroughFields(criteria) {
-    const query = (criteria && criteria.query) || '';
+    if (!criteria || !criteria.query) return criteria;
+
+    const query = criteria.query || '';
     const params = query.split('&');
     const includesString = params.find(param => param.startsWith('include=')) || '';
     const includes = includesString.replace('include=', '').split(',') || [];
@@ -239,6 +241,7 @@ class ResourcefulEndpoint {
       .join('&');
 
     criteria.query = newQuery;
+
     return criteria;
   }
 

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -212,32 +212,34 @@ class ResourcefulEndpoint {
    * @returns {Promise} - A {@link ResourceCollection}
    */
   browse(criteria, options) {
-    const { query } = criteria;
+    return this.transport.get(this.endPointUrl(null, this.getRelatedThroughFields(criteria)), options).then((json) => {
+      return new ResourceCollection(json, criteria, this);
+    });
+  }
+
+  getRelatedThroughFields(criteria) {
+    const query = (criteria && criteria.query) || '';
     const params = query.split('&');
     const includesString = params.find(param => param.startsWith('include=')) || '';
     const includes = includesString.replace('include=', '').split(',') || [];
-    let fields = params.find(param => param.startsWith('fields=')) || '';
+    const fields = (params.find(param => param.startsWith('fields=')) || '').split(',');
 
     const filteredIncludes = includes
       .map((include) => {
-        const relationship = this.resourceful.relationships[include];
-        const { through } = relationship;
+        const { through } = this.resourceful.relationships[include] || {};
         const { fieldNamePath } = this.resourceful.relationships[through] || {};
+
         return fieldNamePath;
       })
       .filter(fieldNamePath => fieldNamePath);
-      fields += `,${filteredIncludes.join(',')}`;
     
     const newQuery = criteria.query
       .split('&')
-      .map(queryItem => queryItem.startsWith('fields=') ? fields : queryItem)
+      .map(queryItem => queryItem.startsWith('fields=') ? fields.concat(filteredIncludes).join(',') : queryItem)
       .join('&');
 
     criteria.query = newQuery;
-
-    return this.transport.get(this.endPointUrl(null, criteria), options).then((json) => {
-      return new ResourceCollection(json, criteria, this);
-    });
+    return criteria;
   }
 
   /**
@@ -547,7 +549,6 @@ class ResourcefulEndpoint {
    * @returns {string}
    */
   criteriaToQuery(criteria) {
-    console.log(criteria);
     let query = `?owner=${this.owner}`;
 
     if (typeof criteria === 'string') {

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -212,67 +212,12 @@ class ResourcefulEndpoint {
    * @returns {Promise} - A {@link ResourceCollection}
    */
   browse(criteria, options) {
+    const query = (criteria || '').hasOwnProperty('query') ? criteria : new Query(criteria);
+    query.addRelatedThroughFields(this.resourceful.relationships || {});
+
     return this.transport
-      .get(this.endPointUrl(null, this.getRelatedThroughFields(criteria)), options)
+      .get(this.endPointUrl(null, query, options))
       .then(json => new ResourceCollection(json, criteria, this));
-  }
-
-  /**
-   * Private
-   * Look through the relationships of a criteria, and include fields from through
-   * relationships - this makes it so that the end user shouldn't know or care that
-   * through relationships exist.
-   *
-   * @param {(string|Query)} criteria - A query string to append to the request
-   *
-   * @returns {(Query)} criteria - A qquery with additional includes if needed
-
-   */
-  getRelatedThroughFields(criteria) {
-    if (!criteria || !criteria.query) return criteria;
-    const query = criteria.query || '';
-    const params = query.split('&');
-    const includes = params.find(param => param.startsWith('include=') || '')
-      .replace('include=', '')
-      .split(',');
-
-    let fields = params.find(param => param.startsWith('fields=')) || '';
-
-    if (fields) {
-      fields = fields.split(',');
-    } else {
-      fields = [];
-    }
-
-    const filteredIncludes = includes
-      .map((include) => {
-        const { through } = this.resourceful.relationships[include] || {};
-
-        if (!through) return false;
-
-        const throughRelationship = this.resourceful.relationships[through] || {};
-
-        // eslint-disable-next-line consistent-return
-        return throughRelationship.fieldNamePath;
-      })
-      .filter(fieldNamePath => fieldNamePath);
-
-    if (!filteredIncludes.length) {
-      return criteria;
-    }
-
-    let newQuery = filteredIncludes && criteria.query
-      .split('&')
-      .map(queryItem => queryItem.startsWith('fields=') ? fields.concat(filteredIncludes).join(',') : queryItem)
-      .join('&');
-
-    if (!newQuery.includes('fields=')) {
-      newQuery = newQuery.concat('&', `fields=${filteredIncludes.join(',')}`);
-    }
-
-    criteria.query = newQuery;
-
-    return criteria;
   }
 
   /**
@@ -589,7 +534,7 @@ class ResourcefulEndpoint {
         query += `&${criteria}`;
       }
     } else if (criteria instanceof Query) {
-      query += `&${criteria.toQueryString()}`;
+      query += `${(criteria.toQueryString() && '&')}${criteria.toQueryString()}`;
     }
 
     return query;

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,7 +382,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -394,7 +393,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3445,14 +3443,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3467,20 +3463,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3597,8 +3590,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3610,7 +3602,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3625,7 +3616,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3633,14 +3623,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3659,7 +3647,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3740,8 +3727,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3753,7 +3739,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3875,7 +3860,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5999,8 +5983,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/test/fixtures/credits-with-through.json
+++ b/test/fixtures/credits-with-through.json
@@ -1,0 +1,162 @@
+{
+  "meta": {
+    "totalCount": 74,
+    "page": 1,
+    "perPage": 24,
+    "first": "\/data\/credits?count=true&fields=ref%2Ctype%2Cref%2Ctitle%2CrelatedMaterialRefs&include=relatedMaterials.assets&owner=demo&page=1&perPage=24&sort=createdAt",
+    "last": "\/data\/credits?count=true&fields=ref%2Ctype%2Cref%2Ctitle%2CrelatedMaterialRefs&include=relatedMaterials.assets&owner=demo&page=4&perPage=24&sort=createdAt",
+    "next": "\/data\/credits?count=true&fields=ref%2Ctype%2Cref%2Ctitle%2CrelatedMaterialRefs&include=relatedMaterials.assets&owner=demo&page=2&perPage=24&sort=createdAt",
+    "linked": {
+      "relatedMaterials.assets": [
+        {
+          "totalCount": 1,
+          "page": 1,
+          "perPage": 100,
+          "first": "\/data\/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=demo%3Aimpastor&page=1&perPage=100",
+          "last": "\/data\/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=demo%3Aimpastor&page=1&perPage=100",
+          "request": "\/data\/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=demo%3Aimpastor"
+        }
+      ]
+    }
+  },
+  "credits": [
+    {
+      "ref": "demo:aidan_gillen_actor_petyr_littlefinger_baelish",
+      "title": "aidan_gillen_actor_petyr_littlefinger_baelish",
+      "type": "other",
+      "relatedMaterialRefs": [
+        "demo:impastor"
+      ]
+    },
+    {
+      "ref": "demo:aimee_richardson_actor_myrcella_baratheon_season_1_2",
+      "title": "aimee_richardson_actor_myrcella_baratheon_season_1_2",
+      "type": "other"
+    },
+    {
+      "ref": "demo:alexander_siddig_actor_doran_martell",
+      "title": "alexander_siddig_actor_doran_martell",
+      "type": "other"
+    },
+    {
+      "ref": "demo:alfie_allen_actor_theon_greyjoy",
+      "title": "alfie_allen_actor_theon_greyjoy",
+      "type": "other"
+    },
+    {
+      "ref": "demo:amrita_acharia_actor_irri",
+      "title": "amrita_acharia_actor_irri",
+      "type": "other"
+    },
+    {
+      "ref": "demo:art_parkinson_actor_rickon_stark",
+      "title": "art_parkinson_actor_rickon_stark",
+      "type": "other"
+    },
+    {
+      "ref": "demo:caricevan_houten_actor_melisandre_of_asshai",
+      "title": "caricevan_houten_actor_melisandre_of_asshai",
+      "type": "other"
+    },
+    {
+      "ref": "demo:charles_dance_actor_tywin_lannister",
+      "title": "charles_dance_actor_tywin_lannister",
+      "type": "other"
+    },
+    {
+      "ref": "demo:ciaran_hinds_actor_mance_rayder",
+      "title": "ciaran_hinds_actor_mance_rayder",
+      "type": "other"
+    },
+    {
+      "ref": "demo:conleth_hill_actor_lord_varys",
+      "title": "conleth_hill_actor_lord_varys",
+      "type": "other"
+    },
+    {
+      "ref": "demo:dean_charles_chapman_actor_tommen_baratheon",
+      "title": "dean_charles_chapman_actor_tommen_baratheon",
+      "type": "other"
+    },
+    {
+      "ref": "demo:diana_rigg_actor_olenna_tyrell",
+      "title": "diana_rigg_actor_olenna_tyrell",
+      "type": "other"
+    },
+    {
+      "ref": "demo:donald_sumpter_actor_maester_luwin",
+      "title": "donald_sumpter_actor_maester_luwin",
+      "type": "other"
+    },
+    {
+      "ref": "demo:ed_skrein_actor_daario_naharis_season_3",
+      "title": "ed_skrein_actor_daario_naharis_season_3",
+      "type": "other"
+    },
+    {
+      "ref": "demo:ellie_kendrick_actor_meera_reed",
+      "title": "ellie_kendrick_actor_meera_reed",
+      "type": "other"
+    },
+    {
+      "ref": "demo:emilia_clarke_actor_daenerys_targaryen",
+      "title": "emilia_clarke_actor_daenerys_targaryen",
+      "type": "other"
+    },
+    {
+      "ref": "demo:esme_bianco_actor_ros",
+      "title": "esme_bianco_actor_ros",
+      "type": "other"
+    },
+    {
+      "ref": "demo:eugene_simon_actor_lancel_lannister",
+      "title": "eugene_simon_actor_lancel_lannister",
+      "type": "other"
+    },
+    {
+      "ref": "demo:finn_jones_actor_loras_tyrell",
+      "title": "finn_jones_actor_loras_tyrell",
+      "type": "other"
+    },
+    {
+      "ref": "demo:gemma_whelan_actor_yara_greyjoy",
+      "title": "gemma_whelan_actor_yara_greyjoy",
+      "type": "other"
+    },
+    {
+      "ref": "demo:gethin_anthony_actor_renly_baratheon",
+      "title": "gethin_anthony_actor_renly_baratheon",
+      "type": "other"
+    },
+    {
+      "ref": "demo:gwendoline_christie_actor_brienne_of_tarth",
+      "title": "gwendoline_christie_actor_brienne_of_tarth",
+      "type": "other"
+    },
+    {
+      "ref": "demo:hannah_murray_actor_gilly",
+      "title": "hannah_murray_actor_gilly",
+      "type": "other"
+    },
+    {
+      "ref": "demo:harry_lloyd_actor_viserys_targaryen",
+      "title": "harry_lloyd_actor_viserys_targaryen",
+      "type": "other"
+    }
+  ],
+  "linked": {
+    "relatedMaterials.assets": [
+      {
+        "ref": "demo:impastor-image",
+        "name": "impastor-image",
+        "contentRef": "demo:impastor",
+        "type": "image",
+        "url": "https:\/\/s3-eu-west-1.amazonaws.com\/demo.datasets.sequoia.piksel.com\/images\/viacom\/Impastors1ep01HD-00DDDE0000112357351303.jpg",
+        "title": "impastor-image",
+        "tags": [
+          "viacom"
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/metadata-descriptor.json
+++ b/test/fixtures/metadata-descriptor.json
@@ -8858,7 +8858,8 @@
             "type"
           ],
           "batchSize": 10,
-          "name": "content"
+          "name": "content",
+          "intersectable": false
         },
         "person": {
           "type": "direct",
@@ -8870,7 +8871,8 @@
             "fullName"
           ],
           "batchSize": 10,
-          "name": "person"
+          "name": "person",
+          "intersectable": false
         },
         "role": {
           "type": "direct",
@@ -8882,7 +8884,59 @@
             "title"
           ],
           "batchSize": 10,
-          "name": "role"
+          "name": "role",
+          "intersectable": false
+        },
+        "character": {
+          "description": "The associated characters",
+          "type": "direct",
+          "resourceType": "characters",
+          "fieldNamePath": "characterRef",
+          "fields": [
+            "ref",
+            "title",
+            "type"
+          ],
+          "name": "character",
+          "intersectable": false,
+          "batchSize": 10
+        },
+        "relatedMaterials": {
+          "type": "direct",
+          "description": "The associated content folder containing materials related to this Credit",
+          "resourceType": "contents",
+          "fieldNamePath": "relatedMaterialRefs",
+          "fields": [
+            "ref",
+            "title",
+            "parentRef",
+            "memberRefs",
+            "type"
+          ],
+          "batchSize": 10,
+          "name": "relatedMaterials",
+          "intersectable": false
+        },
+        "relatedMaterials.assets": {
+          "type": "indirect",
+          "description": "The associated assets through associated folders containing materials related to the Credit",
+          "through": "relatedMaterials",
+          "resourceType": "assets",
+          "filterName": "withContentRef",
+          "fields": [
+            "ref",
+            "name",
+            "contentRef",
+            "type",
+            "url",
+            "fileFormat",
+            "title",
+            "fileSize",
+            "tags"
+          ],
+          "batchSize": 10,
+          "name": "relatedMaterials.assets",
+          "intersectable": false
         }
       },
       "description": "Represents a credit of a content",

--- a/test/spec/resource.js
+++ b/test/spec/resource.js
@@ -69,11 +69,15 @@ describe('Resource', () => {
     });
 
     describe('save', () => {
-      it('should reject with an error message as there is no endpoint to save to', async () => expect(resource.save()).rejects.toEqual(NO_RESOURCEFUL_ENDPOINT_ERROR));
+      it('should reject with an error message as there is no endpoint to save to', async () => {
+        expect(resource.save()).rejects.toEqual(NO_RESOURCEFUL_ENDPOINT_ERROR);
+      });
     });
 
     describe('destroy', () => {
-      it('should reject with an error message as there is no endpoint to delete to', async () => expect(resource.destroy()).rejects.toEqual(NO_RESOURCEFUL_ENDPOINT_ERROR));
+      it('should reject with an error message as there is no endpoint to delete to', async () => {
+        expect(resource.destroy()).rejects.toEqual(NO_RESOURCEFUL_ENDPOINT_ERROR);
+      });
     });
   });
 

--- a/test/spec/resource_collection.js
+++ b/test/spec/resource_collection.js
@@ -216,10 +216,8 @@ describe('ResourceCollection', () => {
         const { collection } = result;
         const itemWithRelatedMaterialRefs = collection[0];
 
-        expect(
-          itemWithRelatedMaterialRefs
-          && itemWithRelatedMaterialRefs.relatedMaterialRefs
-        ).toBeDefined();
+        expect(itemWithRelatedMaterialRefs && itemWithRelatedMaterialRefs.relatedMaterialRefs)
+          .toBeDefined();
 
         expect(itemWithRelatedMaterialRefs.relatedMaterialRefs.length).toEqual(1);
       });

--- a/test/spec/resource_collection.js
+++ b/test/spec/resource_collection.js
@@ -5,17 +5,22 @@ import Transport from '../../lib/transport';
 import mediaItemFixture from '../fixtures/media-items.json';
 import lastMediaItemFixture from '../fixtures/media-items-12.json';
 import metadataDescriptorFixture from '../fixtures/metadata-descriptor.json';
+import creditsWithThroughFixture from '../fixtures/credits-with-through.json';
 
 describe('ResourceCollection', () => {
-  const mockDescriptor = Object.assign(metadataDescriptorFixture.resourcefuls.contents, {
-    location: 'http://localhost/metadata',
-    tenant: 'test',
-    pluralName: 'contents'
-  });
-  const resourcefulEndpoint = new ResourcefulEndpoint(new Transport(), mockDescriptor);
+  let mockDescriptor;
+  let resourcefulEndpoint;
   let resourceCollection;
 
   beforeEach(() => {
+    mockDescriptor = Object.assign(metadataDescriptorFixture.resourcefuls.contents, {
+      location: 'http://localhost/metadata',
+      tenant: 'test',
+      pluralName: 'contents'
+    });
+
+    resourcefulEndpoint = new ResourcefulEndpoint(new Transport(), mockDescriptor);
+
     resourceCollection = new ResourceCollection(mediaItemFixture);
   });
 
@@ -172,6 +177,85 @@ describe('ResourceCollection', () => {
       const result = resourceCollection.setData(rawData);
       expect(result.rawData.linked).toEqual({});
       expect(result.collection).toEqual([]);
+    });
+
+    describe('through relationships', () => {
+      let rawData;
+      beforeEach(() => {
+        mockDescriptor = Object.assign(metadataDescriptorFixture.resourcefuls.credits, {
+          location: 'http://localhost/metadata',
+          tenant: 'test',
+          pluralName: 'credits'
+        });
+        resourcefulEndpoint = new ResourcefulEndpoint(new Transport(), mockDescriptor);
+        resourceCollection = new ResourceCollection(
+          mediaItemFixture,
+          null,
+          resourcefulEndpoint
+        );
+        rawData = creditsWithThroughFixture;
+      });
+
+      it('has a resourcefulEndpoint that has a relationship that has a through relationship', () => {
+        const relationship = resourcefulEndpoint.resourceful.relationships['relatedMaterials.assets'];
+        expect(relationship).toBeDefined();
+        expect(relationship.through).toBeDefined();
+      });
+
+      it('has rawData', () => {
+        expect(rawData).toBeDefined();
+      });
+
+      it('has a collection', () => {
+        const result = resourceCollection.setData(rawData);
+        expect(result && result.collection).toBeDefined();
+      });
+
+      it('has an item in collection that has values in relatedMaterialRefs', () => {
+        const result = resourceCollection.setData(rawData);
+        const { collection } = result;
+        const itemWithRelatedMaterialRefs = collection[0];
+
+        expect(
+          itemWithRelatedMaterialRefs &&
+          itemWithRelatedMaterialRefs.relatedMaterialRefs
+        ).toBeDefined();
+
+        expect(itemWithRelatedMaterialRefs.relatedMaterialRefs.length).toEqual(1);
+      });
+
+      describe('item with relatedMaterialRefs', () => {
+        let result;
+        let collection;
+        let itemWithRelatedMaterialRefs;
+
+        beforeEach(() => {
+          result = resourceCollection.setData(rawData);
+          collection = result && result.collection;
+          itemWithRelatedMaterialRefs = collection[0];
+        });
+
+        it('has linked data', () => {
+          expect(itemWithRelatedMaterialRefs.linked).toBeDefined();
+        });
+
+        it('has the same number of linked data the amount of relatedMaterialRefs', () => {
+          const refs = itemWithRelatedMaterialRefs.relatedMaterialRefs;
+          const linked = itemWithRelatedMaterialRefs.linked['relatedMaterials.assets'];
+          expect(refs.length).toEqual(linked.length);
+        });
+
+        it('has matching linked data and relatedMaterialRefs', () => {
+          const refs = itemWithRelatedMaterialRefs.relatedMaterialRefs;
+          const linked = itemWithRelatedMaterialRefs.linked['relatedMaterials.assets'];
+
+          linked
+            .map(l => l.contentRef)
+            .forEach((l) => {
+              expect(refs.includes(l));
+            });
+        });
+      });
     });
   });
 

--- a/test/spec/resource_collection.js
+++ b/test/spec/resource_collection.js
@@ -183,7 +183,9 @@ describe('ResourceCollection', () => {
     });
 
     describe('nextPage', () => {
-      it('should call "fetch" when there is a next page of results', async () => expect(resourceCollection.nextPage()).resolves.toEqual(successfulFetch));
+      it('should call "fetch" when there is a next page of results', async () => {
+        expect(resourceCollection.nextPage()).resolves.toEqual(successfulFetch);
+      });
 
       it('should reject when there is no next page of results', async () => {
         delete resourceCollection.rawData.meta.next;

--- a/test/spec/resource_collection.js
+++ b/test/spec/resource_collection.js
@@ -217,8 +217,8 @@ describe('ResourceCollection', () => {
         const itemWithRelatedMaterialRefs = collection[0];
 
         expect(
-          itemWithRelatedMaterialRefs &&
-          itemWithRelatedMaterialRefs.relatedMaterialRefs
+          itemWithRelatedMaterialRefs
+          && itemWithRelatedMaterialRefs.relatedMaterialRefs
         ).toBeDefined();
 
         expect(itemWithRelatedMaterialRefs.relatedMaterialRefs.length).toEqual(1);
@@ -232,7 +232,7 @@ describe('ResourceCollection', () => {
         beforeEach(() => {
           result = resourceCollection.setData(rawData);
           collection = result && result.collection;
-          itemWithRelatedMaterialRefs = collection[0];
+          [itemWithRelatedMaterialRefs] = collection;
         });
 
         it('has linked data', () => {

--- a/test/spec/resourceful_endpoint.js
+++ b/test/spec/resourceful_endpoint.js
@@ -353,12 +353,16 @@ describe('ResourcefulEndpoint', () => {
           expect(result.initialCriteria.query).toEqual('include=relatedMaterials');
         });
 
-        it('should return a query with fields if the relationship the query mentions is a through relationship, but the query does not mention fields', async () => {
-          const query = new Query('include=relatedMaterials.assets');
-          const result = await resourcefulEndpoint.browse(query);
-          expect(result.initialCriteria.query)
-            .toEqual('include=relatedMaterials.assets&fields=relatedMaterialRefs');
-        });
+        it(
+          `should return a query with fields if the relationship the query mentions
+          is a through relationship, but the query does not mention fields`,
+          async () => {
+            const query = new Query('include=relatedMaterials.assets');
+            const result = await resourcefulEndpoint.browse(query);
+            expect(result.initialCriteria.query)
+              .toEqual('include=relatedMaterials.assets&fields=relatedMaterialRefs');
+          }
+        );
 
         it('should append a field if the relationship the query mentions is a through relationship and mentions fields', async () => {
           const query = new Query('include=relatedMaterials.assets&fields=dave');

--- a/test/spec/resourceful_endpoint.js
+++ b/test/spec/resourceful_endpoint.js
@@ -5,12 +5,13 @@ import ResourcefulEndpoint from '../../lib/resourceful_endpoint.js';
 import Transport from '../../lib/transport.js';
 import ResourceCollection from '../../lib/resource_collection.js';
 import mediaItemsFixture from '../fixtures/media-items.json';
+import creditsWithThrough from '../fixtures/credits-with-through.json';
 
 const pluralName = 'contents';
 const singularName = 'content';
 const hyphenatedPluralName = 'contents';
 const serviceName = 'metadata';
-const relationships = { test: { desription: 'test', resourceType: 'test' } };
+const relationships = { test: { description: 'test', resourceType: 'test' } };
 
 const mockDescriptor = {
   location: 'http://localhost/metadata',
@@ -278,6 +279,94 @@ describe('ResourcefulEndpoint', () => {
       it('should resolve with a ResourceCollection', async () => expect(resourcefulEndpoint.browse()).resolves.toEqual({
         asymmetricMatch: actual => actual instanceof ResourceCollection
       }));
+
+      describe('related through field', () => {
+        beforeEach(() => {
+          fetchMock.mock('*', creditsWithThrough, { overwriteRoutes: true });
+          resourcefulEndpoint = new ResourcefulEndpoint(
+            transport,
+            {
+              location: 'http://localhost/metadata',
+              pluralName: 'credits',
+              singularName: 'credit',
+              hyphenatedPluralName: 'credits',
+              serviceName: 'metadata',
+              relationships: {
+                relatedMaterials: {
+                  type: 'direct',
+                  description: 'The associated content folder containing materials related to this Credit',
+                  resourceType: 'contents',
+                  fieldNamePath: 'relatedMaterialRefs',
+                  fields: [
+                    'ref',
+                    'title',
+                    'parentRef',
+                    'memberRefs',
+                    'type'
+                  ],
+                  batchSize: 10,
+                  name: 'relatedMaterials',
+                  intersectable: false
+                },
+                'relatedMaterials.assets': {
+                  type: 'indirect',
+                  description: 'The associated assets through associated folders containing materials related to the Credit',
+                  through: 'relatedMaterials',
+                  resourceType: 'assets',
+                  filterName: 'withContentRef',
+                  fields: [
+                    'ref',
+                    'name',
+                    'contentRef',
+                    'type',
+                    'url',
+                    'fileFormat',
+                    'title',
+                    'fileSize',
+                    'tags'
+                  ],
+                  batchSize: 10,
+                  name: 'relatedMaterials.assets',
+                  intersectable: false
+                }
+              },
+              tenant: 'test'
+            }
+          );
+        });
+
+        it('should return no query if passed no query', async () => {
+          const result = await resourcefulEndpoint.browse();
+
+          expect(result.initialCriteria).not.toBeDefined();
+        });
+
+        it('should return a query with an empty string if passed an empty string as a query', async () => {
+          const result = await resourcefulEndpoint.browse('');
+
+          expect(result.initialCriteria).toEqual('');
+        });
+
+        it('should return a query if the relationship the query mentions is not a through relationship', async () => {
+          const query = new Query('include=relatedMaterials');
+          const result = await resourcefulEndpoint.browse(query);
+          expect(result.initialCriteria.query).toEqual('include=relatedMaterials');
+        });
+
+        it('should return a query with fields if the relationship the query mentions is a through relationship, but the query does not mention fields', async () => {
+          const query = new Query('include=relatedMaterials.assets');
+          const result = await resourcefulEndpoint.browse(query);
+          expect(result.initialCriteria.query)
+            .toEqual('include=relatedMaterials.assets&fields=relatedMaterialRefs');
+        });
+
+        it('should append a field if the relationship the query mentions is a through relationship and mentions fields', async () => {
+          const query = new Query('include=relatedMaterials.assets&fields=dave');
+          const result = await resourcefulEndpoint.browse(query);
+          expect(result.initialCriteria.query)
+            .toEqual('include=relatedMaterials.assets&fields=dave,relatedMaterialRefs');
+        });
+      });
     });
 
     describe('all', () => {

--- a/test/spec/session.js
+++ b/test/spec/session.js
@@ -128,7 +128,9 @@ describe('session', () => {
       expect(fetchMock.called(customTokenUri)).toBe(true);
     });
 
-    it('should reject when no secret is provided for oauth login', async () => expect(session.authenticateWithCredentials('test', 'password', { strategy: 'oauth' })).rejects.toEqual(NO_OAUTH_SECRET_PROVIDED));
+    it('should reject when no secret is provided for oauth login', async () => {
+      expect(session.authenticateWithCredentials('test', 'password', { strategy: 'oauth' })).rejects.toEqual(NO_OAUTH_SECRET_PROVIDED);
+    });
   });
 
   describe('setDirectory', () => {


### PR DESCRIPTION
Before this merge request, when getting `relatedMaterials.assets` from credits, we were returned all relatedMaterials rather than just the ones related to the credit. This merge request attempts to fix this.