### PR TITLE
Add ability for the SDK to encode urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add `encodeUri` configuration option.  Will cause the client to automatically encode request urls it generates.
+
 ## 1.9.0
 
 * Proper error message returned when a request is failed (taken from response.body.message)

--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,8 @@ import {
  * @property {string?} identityUri - Optional identityUri to pass through to {@link Session}.
  * @property {string?} token - Token to authenticate with.
  * @property {string?} tenant - Tenant to initialize with.
- * @property {boolean?} enableCache - Indicates wether to cache service descriptors in {@link Registry}.
+ * @property {boolean?} enableCache - Indicates whether to cache service descriptors in {@link Registry}.
+ * @property {encodeUri?} encodeURI - Indicates whether to encode URIs before requesting. Will not re-encode existing sequences (e.g. `%20` will stay as `%20`, but `%2` will encode to `%202`)
  */
 
 /**
@@ -77,9 +78,9 @@ import {
  */
 class Client {
   constructor({
-    directory, registryUri, identityUri, token, tenant, enableCache
+    directory, registryUri, identityUri, token, tenant, enableCache, encodeUri
   }) {
-    this.transport = new Transport();
+    this.transport = new Transport({}, encodeUri);
     this.registry = new Registry(this.transport, registryUri, enableCache);
     this.session = new Session(this.transport, directory, this.registry, identityUri);
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,7 +14,8 @@ import {
  * @property {string?} token - Token to authenticate with.
  * @property {string?} tenant - Tenant to initialize with.
  * @property {boolean?} enableCache - Indicates whether to cache service descriptors in {@link Registry}.
- * @property {encodeUri?} encodeURI - Indicates whether to encode URIs before requesting. Will not re-encode existing sequences (e.g. `%20` will stay as `%20`, but `%2` will encode to `%202`)
+ * @property {encodeUri?} encodeURI - Indicates whether to encode URIs before requesting in {@link Transport}.
+ *                                    Will not re-encode existing sequences (e.g. `%20` will stay as `%20`, but `%2` will encode to `%202`)
  */
 
 /**

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -1,3 +1,5 @@
+import urlEncoder from 'encodeurl';
+
 /**
  * Handles fetching.
  *
@@ -24,7 +26,7 @@ class Transport {
    * @see {@link https://github.github.io/fetch/#options}
    */
 
-  constructor(options = {}) {
+  constructor(fetchOptions = {}, encodeUri = false) {
     this.defaults = Object.assign(
       {},
       {
@@ -35,8 +37,19 @@ class Transport {
           Accept: 'application/json'
         }
       },
-      options
+      fetchOptions
     );
+    this.encodeUri = encodeUri;
+  }
+
+  encodeUrl(url) {
+    if (this.encodeUri === true) {
+      // use encodeUrl dep as it won't double-encode
+      this.encodeUrl = u => urlEncoder(u);
+      return urlEncoder(url);
+    }
+    this.encodeUrl = u => u;
+    return url;
   }
 
   /**
@@ -48,7 +61,7 @@ class Transport {
    * @returns {Promise}
    */
   fetchWithDefaults(url, options = {}) {
-    return fetch(url, Object.assign({}, this.defaults, options)).then((response) => {
+    return fetch(this.encodeUrl(url), Object.assign({}, this.defaults, options)).then((response) => {
       if (!response.ok) {
         return response.json().then(
           (responseBody) => {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -7,6 +7,7 @@ import urlEncoder from 'encodeurl';
  * from {@link ServiceDescriptor#resourcefulEndpoint} or {@link ServiceDescriptor#businessEndpoint}
  *
  * @param {TransportDefaults?} options - The options to use with all fetch requests
+ * @param {string?} encodeUri - Indicate whether to encode request URIs generated. Defaults `false`
  *
  * @property {TransportDefaults?} defaults - Stored from the initial 'options' parameter merged with the standard defaults
  *
@@ -42,6 +43,11 @@ class Transport {
     this.encodeUri = encodeUri;
   }
 
+  /**
+   * Encodes the request url if `this.encodeUri` is true.
+   *
+   * @param {string} url - the url to potentially encode
+   */
   encodeUrl(url) {
     if (this.encodeUri === true) {
       // use encodeUrl dep as it won't double-encode

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,7 +382,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -394,7 +393,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2486,6 +2484,11 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
@@ -3445,14 +3448,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3467,20 +3468,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3597,8 +3595,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3610,7 +3607,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3625,7 +3621,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3633,14 +3628,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3659,7 +3652,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3740,8 +3732,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3753,7 +3744,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3875,7 +3865,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5999,8 +5988,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "date-fns": "^1.29.0",
+    "encodeurl": "^1.0.2",
     "lodash.delay": "^4.1.1",
     "qs": "^6.5.2"
   },

--- a/test/spec/client.js
+++ b/test/spec/client.js
@@ -80,6 +80,16 @@ describe('Client', () => {
       expect(client.registry.cache).toBe(true);
     });
 
+    it('should pass the encodeUri value to Transport', () => {
+      client = new Client({
+        directory,
+        registryUri,
+        identityUri,
+        encodeUri: true
+      });
+      expect(client.transport.encodeUri).toBe(true);
+    });
+
     it('should accept an optional `identityUri`', () => {
       client = new Client({ directory, registryUri });
 

--- a/test/spec/transport.js
+++ b/test/spec/transport.js
@@ -72,6 +72,25 @@ describe('transport', () => {
 
       return expect(transport.get('/')).rejects.toEqual(expect.any(Object));
     });
+
+    it('should not encode request url when encodeUri not set', async () => {
+      fetchMock.mock('/%20|é%@', {
+        body: { test: 'response' }
+      });
+
+      return expect(transport.get('/%20|é%@')).resolves.toEqual(expect.objectContaining({ test: 'response' }));
+    });
+
+    it('should encode request url when encodeUri set', async () => {
+      // Only should encode unsafe chars, and should not double-encode already encoded sequences
+      transport = new Transport({}, true);
+
+      fetchMock.mock('/%20%7C%C3%A9%25@', {
+        body: { test: 'response' }
+      });
+
+      return expect(transport.get('/%20|é%@')).resolves.toEqual(expect.objectContaining({ test: 'response' }));
+    });
   });
 
   describe('public method', () => {


### PR DESCRIPTION
This adds a configuration to the client to encode request urls.  This is needed because some services (such as Amazon's API Gateway) strictly adhere to https://www.ietf.org/rfc/rfc1738.txt (section 2.2) which results in 400 errors when performing certain queries such as those using `oneOrMoreOf`.