### PR TITLE
Metadata/People through fields do not have the required filter in the descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
+* Adjust through relationship logic to use the relationship filter name to determine the fieldNamePath which needs to be filtered against - this field will not always be present on the originating resource's fields
 ## 1.10.0
-
+ 
 * Add `encodeUri` configuration option.  Will cause the client to automatically encode request urls it generates.
 * Add addRelatedThroughFields to the Query class, update logic in resourceful_endpoint browse method to use this method to fetch additional fields required on included through relationships to support their use with graphical display descriptors for example.
 

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -102,11 +102,16 @@ class ResourceCollection {
 
               const { fieldNamePath } = this.resourcefulEndpoint.resourceful.relationships[through];
               const throughFields = resource[fieldNamePath] || [];
-              const filteredFieldNamePath = this.resourcefulEndpoint.resourceful.filters
-                && this.resourcefulEndpoint.resourceful.filters[filterName]
-                && this.resourcefulEndpoint.resourceful.filters[filterName].fieldNamePath;
 
-              return throughFields.some(field => field === item[filteredFieldNamePath]);
+              // Our first attempt at getting the filter we need relied on what filters were in
+              // this.resourcefulEndpoint.filters. This worked fine for metadata/credits, but
+              // metadata/people does not have withContentRef. The following code is not pretty,
+              // but as the filters follow the same naming convention, deriving the filter we need
+              // from the filterName works fine.
+              let parsedFilterName = filterName.slice(4);
+              parsedFilterName = `${parsedFilterName.charAt(0).toLowerCase()}${parsedFilterName.slice(1)}`;
+
+              return throughFields.some(field => field === item[parsedFilterName]);
             });
           });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Sequoia client SDK for Javascript",
   "main": "dist/web/sequoia-client.js",
   "scripts": {

--- a/test/fixtures/metadata-descriptor.json
+++ b/test/fixtures/metadata-descriptor.json
@@ -13188,6 +13188,43 @@
           ],
           "batchSize": 10,
           "name": "credits"
+        },
+        "relatedMaterials": {
+          "type": "direct",
+          "description": "The associated content folder containing materials related to this Person",
+          "resourceType": "contents",
+          "fieldNamePath": "relatedMaterialRefs",
+          "fields": [
+            "ref",
+            "title",
+            "parentRef",
+            "memberRefs",
+            "type"
+          ],
+          "batchSize": 10,
+          "name": "relatedMaterials",
+          "intersectable": false
+        },
+        "relatedMaterials.assets": {
+          "type": "indirect",
+          "description": "The associated assets through associated folders containing materials related to the Person",
+          "through": "relatedMaterials",
+          "resourceType": "assets",
+          "filterName": "withContentRef",
+          "fields": [
+            "ref",
+            "name",
+            "contentRef",
+            "type",
+            "url",
+            "fileFormat",
+            "title",
+            "fileSize",
+            "tags"
+          ],
+          "batchSize": 10,
+          "name": "relatedMaterials.assets",
+          "intersectable": false
         }
       },
       "description": "Represents a person",

--- a/test/fixtures/people-with-through.json
+++ b/test/fixtures/people-with-through.json
@@ -1,0 +1,138 @@
+{
+  "meta": {
+    "totalCount": 440,
+    "page": 1,
+    "perPage": 24,
+    "first": "\/data\/people?count=true&fields=ref%2CfullName%2CgivenName%2CotherNames%2CfamilyName%2CyearOfDebut%2ChonorificPrefix%2Csuffix%2CplaceOfBirth%2CfullName%2CrelatedMaterialRefs&include=relatedMaterials.assets&owner=demo&page=1&perPage=24&sort=-updatedAt",
+    "last": "\/data\/people?count=true&fields=ref%2CfullName%2CgivenName%2CotherNames%2CfamilyName%2CyearOfDebut%2ChonorificPrefix%2Csuffix%2CplaceOfBirth%2CfullName%2CrelatedMaterialRefs&include=relatedMaterials.assets&owner=demo&page=19&perPage=24&sort=-updatedAt",
+    "next": "\/data\/people?count=true&fields=ref%2CfullName%2CgivenName%2CotherNames%2CfamilyName%2CyearOfDebut%2ChonorificPrefix%2Csuffix%2CplaceOfBirth%2CfullName%2CrelatedMaterialRefs&include=relatedMaterials.assets&owner=demo&page=2&perPage=24&sort=-updatedAt",
+    "linked": {
+      "relatedMaterials.assets": [
+        {
+          "totalCount": 1,
+          "page": 1,
+          "perPage": 100,
+          "first": "\/data\/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=demo%3Aimpastor&page=1&perPage=100",
+          "last": "\/data\/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=demo%3Aimpastor&page=1&perPage=100",
+          "request": "\/data\/assets?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=demo%3Aimpastor"
+        }
+      ]
+    }
+  },
+  "people": [
+    {
+      "ref": "demo:gethin_anthony",
+      "fullName": "Gethin Anthony",
+      "relatedMaterialRefs": [
+        "demo:impastor"
+      ]
+    },
+    {
+      "ref": "demo:gwendoline_christie",
+      "fullName": "Gwendoline Christie"
+    },
+    {
+      "ref": "demo:harry_lloyd",
+      "fullName": "Harry Lloyd"
+    },
+    {
+      "ref": "demo:iain_glen",
+      "fullName": "Iain Glen"
+    },
+    {
+      "ref": "demo:ian_mc_elhinney",
+      "fullName": "Ian McElhinney"
+    },
+    {
+      "ref": "demo:isaac_hempstead_wright",
+      "fullName": "Isaac Hempstead-Wright"
+    },
+    {
+      "ref": "demo:iwan_rheon",
+      "fullName": "Iwan Rheon"
+    },
+    {
+      "ref": "demo:jack_gleeson",
+      "fullName": "Jack Gleeson"
+    },
+    {
+      "ref": "demo:jai_courtney",
+      "fullName": "Jai Courtney"
+    },
+    {
+      "ref": "demo:james_cosmo",
+      "fullName": "James Cosmo"
+    },
+    {
+      "ref": "demo:jerome_flynn",
+      "fullName": "Jerome Flynn"
+    },
+    {
+      "ref": "demo:john_moore",
+      "fullName": "John Moore"
+    },
+    {
+      "ref": "demo:jonathan_pryce",
+      "fullName": "Jonathan Pryce"
+    },
+    {
+      "ref": "demo:julian_glover",
+      "fullName": "Julian Glover"
+    },
+    {
+      "ref": "demo:kate_dickie",
+      "fullName": "Kate Dickie"
+    },
+    {
+      "ref": "demo:kerry_ingram",
+      "fullName": "Kerry Ingram"
+    },
+    {
+      "ref": "demo:lino_facioli",
+      "fullName": "Lino Facioli"
+    },
+    {
+      "ref": "demo:mackenzie_crook",
+      "fullName": "Mackenzie Crook"
+    },
+    {
+      "ref": "demo:maisie_williams",
+      "fullName": "Maisie Williams"
+    },
+    {
+      "ref": "demo:michael_mc_elhatton",
+      "fullName": "Michael McElhatton"
+    },
+    {
+      "ref": "demo:michelle_fairley",
+      "fullName": "Michelle Fairley"
+    },
+    {
+      "ref": "demo:michiel_huisman",
+      "fullName": "Michiel Huisman"
+    },
+    {
+      "ref": "demo:mila_kunis",
+      "fullName": "Mila Kunis"
+    },
+    {
+      "ref": "demo:natalia_tena",
+      "fullName": "Natalia Tena"
+    }
+  ],
+  "linked": {
+    "relatedMaterials.assets": [
+      {
+        "ref": "demo:impastor-image",
+        "name": "impastor-image",
+        "contentRef": "demo:impastor",
+        "type": "image",
+        "url": "https:\/\/s3-eu-west-1.amazonaws.com\/demo.datasets.sequoia.piksel.com\/images\/viacom\/Impastors1ep01HD-00DDDE0000112357351303.jpg",
+        "title": "impastor-image",
+        "tags": [
+          "viacom"
+        ]
+      }
+    ]
+  }
+}

--- a/test/spec/resource_collection.js
+++ b/test/spec/resource_collection.js
@@ -6,6 +6,7 @@ import mediaItemFixture from '../fixtures/media-items.json';
 import lastMediaItemFixture from '../fixtures/media-items-12.json';
 import metadataDescriptorFixture from '../fixtures/metadata-descriptor.json';
 import creditsWithThroughFixture from '../fixtures/credits-with-through.json';
+import peopleWithThroughFixture from '../fixtures/people-with-through.json';
 
 describe('ResourceCollection', () => {
   let mockDescriptor;
@@ -180,78 +181,157 @@ describe('ResourceCollection', () => {
     });
 
     describe('through relationships', () => {
-      let rawData;
-      beforeEach(() => {
-        mockDescriptor = Object.assign(metadataDescriptorFixture.resourcefuls.credits, {
-          location: 'http://localhost/metadata',
-          tenant: 'test',
-          pluralName: 'credits'
-        });
-        resourcefulEndpoint = new ResourcefulEndpoint(new Transport(), mockDescriptor);
-        resourceCollection = new ResourceCollection(
-          mediaItemFixture,
-          null,
-          resourcefulEndpoint
-        );
-        rawData = creditsWithThroughFixture;
-      });
-
-      it('has a resourcefulEndpoint that has a relationship that has a through relationship', () => {
-        const relationship = resourcefulEndpoint.resourceful.relationships['relatedMaterials.assets'];
-        expect(relationship).toBeDefined();
-        expect(relationship.through).toBeDefined();
-      });
-
-      it('has rawData', () => {
-        expect(rawData).toBeDefined();
-      });
-
-      it('has a collection', () => {
-        const result = resourceCollection.setData(rawData);
-        expect(result && result.collection).toBeDefined();
-      });
-
-      it('has an item in collection that has values in relatedMaterialRefs', () => {
-        const result = resourceCollection.setData(rawData);
-        const { collection } = result;
-        const itemWithRelatedMaterialRefs = collection[0];
-
-        expect(itemWithRelatedMaterialRefs && itemWithRelatedMaterialRefs.relatedMaterialRefs)
-          .toBeDefined();
-
-        expect(itemWithRelatedMaterialRefs.relatedMaterialRefs.length).toEqual(1);
-      });
-
-      describe('item with relatedMaterialRefs', () => {
-        let result;
-        let collection;
-        let itemWithRelatedMaterialRefs;
-
+      describe('credits', () => {
+        let rawData;
         beforeEach(() => {
-          result = resourceCollection.setData(rawData);
-          collection = result && result.collection;
-          [itemWithRelatedMaterialRefs] = collection;
+          mockDescriptor = Object.assign(metadataDescriptorFixture.resourcefuls.credits, {
+            location: 'http://localhost/metadata',
+            tenant: 'test',
+            pluralName: 'credits'
+          });
+          resourcefulEndpoint = new ResourcefulEndpoint(new Transport(), mockDescriptor);
+          resourceCollection = new ResourceCollection(
+            mediaItemFixture,
+            null,
+            resourcefulEndpoint
+          );
+          rawData = creditsWithThroughFixture;
         });
 
-        it('has linked data', () => {
-          expect(itemWithRelatedMaterialRefs.linked).toBeDefined();
+        it('has a resourcefulEndpoint that has a relationship that has a through relationship', () => {
+          const relationship = resourcefulEndpoint.resourceful.relationships['relatedMaterials.assets'];
+          expect(relationship).toBeDefined();
+          expect(relationship.through).toBeDefined();
         });
 
-        it('has the same number of linked data the amount of relatedMaterialRefs', () => {
-          const refs = itemWithRelatedMaterialRefs.relatedMaterialRefs;
-          const linked = itemWithRelatedMaterialRefs.linked['relatedMaterials.assets'];
-          expect(refs.length).toEqual(linked.length);
+        it('has rawData', () => {
+          expect(rawData).toBeDefined();
         });
 
-        it('has matching linked data and relatedMaterialRefs', () => {
-          const refs = itemWithRelatedMaterialRefs.relatedMaterialRefs;
-          const linked = itemWithRelatedMaterialRefs.linked['relatedMaterials.assets'];
+        it('has a collection', () => {
+          const result = resourceCollection.setData(rawData);
+          expect(result && result.collection).toBeDefined();
+        });
 
-          linked
-            .map(l => l.contentRef)
-            .forEach((l) => {
-              expect(refs.includes(l));
-            });
+        it('has an item in collection that has values in relatedMaterialRefs', () => {
+          const result = resourceCollection.setData(rawData);
+          const { collection } = result;
+          const itemWithRelatedMaterialRefs = collection[0];
+
+          expect(itemWithRelatedMaterialRefs && itemWithRelatedMaterialRefs.relatedMaterialRefs)
+            .toBeDefined();
+
+          expect(itemWithRelatedMaterialRefs.relatedMaterialRefs.length).toEqual(1);
+        });
+
+        describe('item with relatedMaterialRefs', () => {
+          let result;
+          let collection;
+          let itemWithRelatedMaterialRefs;
+
+          beforeEach(() => {
+            result = resourceCollection.setData(rawData);
+            collection = result && result.collection;
+            [itemWithRelatedMaterialRefs] = collection;
+          });
+
+          it('has linked data', () => {
+            expect(itemWithRelatedMaterialRefs.linked).toBeDefined();
+          });
+
+          it('has the same number of linked data the amount of relatedMaterialRefs', () => {
+            const refs = itemWithRelatedMaterialRefs.relatedMaterialRefs;
+            const linked = itemWithRelatedMaterialRefs.linked['relatedMaterials.assets'];
+            expect(refs.length).toEqual(linked.length);
+          });
+
+          it('has matching linked data and relatedMaterialRefs', () => {
+            const refs = itemWithRelatedMaterialRefs.relatedMaterialRefs;
+            const linked = itemWithRelatedMaterialRefs.linked['relatedMaterials.assets'];
+
+            linked
+              .map(l => l.contentRef)
+              .forEach((l) => {
+                expect(refs.includes(l));
+              });
+          });
+        });
+      });
+
+      describe('people', () => {
+        let rawData;
+        beforeEach(() => {
+          mockDescriptor = Object.assign(metadataDescriptorFixture.resourcefuls.people, {
+            location: 'http://localhost/metadata',
+            tenant: 'test',
+            pluralName: 'people'
+          });
+          resourcefulEndpoint = new ResourcefulEndpoint(new Transport(), mockDescriptor);
+          resourceCollection = new ResourceCollection(
+            mediaItemFixture,
+            null,
+            resourcefulEndpoint
+          );
+          rawData = peopleWithThroughFixture;
+        });
+
+        it('has a resourcefulEndpoint that has a relationship that has a through relationship', () => {
+          const relationship = resourcefulEndpoint.resourceful.relationships['relatedMaterials.assets'];
+          expect(relationship).toBeDefined();
+          expect(relationship.through).toBeDefined();
+        });
+
+        it('has rawData', () => {
+          expect(rawData).toBeDefined();
+        });
+
+        it('has a collection', () => {
+          const result = resourceCollection.setData(rawData);
+          expect(result && result.collection).toBeDefined();
+        });
+
+        it('has an item in collection that has values in relatedMaterialRefs', () => {
+          const result = resourceCollection.setData(rawData);
+          const { collection } = result;
+          const itemWithRelatedMaterialRefs = collection[0];
+
+          expect(itemWithRelatedMaterialRefs && itemWithRelatedMaterialRefs.relatedMaterialRefs)
+            .toBeDefined();
+
+          expect(itemWithRelatedMaterialRefs.relatedMaterialRefs.length).toEqual(1);
+        });
+
+        describe('item with relatedMaterialRefs', () => {
+          let result;
+          let collection;
+          let itemWithRelatedMaterialRefs;
+
+          beforeEach(() => {
+            result = resourceCollection.setData(rawData);
+            collection = result && result.collection;
+            [itemWithRelatedMaterialRefs] = collection;
+          });
+
+          it('has linked data', () => {
+            expect(itemWithRelatedMaterialRefs.linked).toBeDefined();
+          });
+
+          it('has the same number of linked data the amount of relatedMaterialRefs', () => {
+            const refs = itemWithRelatedMaterialRefs.relatedMaterialRefs;
+            const linked = itemWithRelatedMaterialRefs.linked['relatedMaterials.assets'];
+            expect(refs.length).toEqual(linked.length);
+          });
+
+          it('has matching linked data and relatedMaterialRefs', () => {
+            const refs = itemWithRelatedMaterialRefs.relatedMaterialRefs;
+            const linked = itemWithRelatedMaterialRefs.linked['relatedMaterials.assets'];
+
+            linked
+              .map(l => l.contentRef)
+              .forEach((l) => {
+                expect(refs.includes(l));
+              });
+          });
         });
       });
     });


### PR DESCRIPTION
Metadata / People does not have a filter called withContentRef. People has a through relationship who has a fieldName of withContentRef. Before this change, in order to decide whether a linked data belongs to an item, we looked at the filters, and grabbed the fieldNamePath from the filter. After this change, we take the relationship's fieldNamePath, `withContentRef`, remove the `with`, and lowercase the first letter to get `contentRef`.

It's not very pretty, but it works, and as filters follow the same naming convention it should continue to work.