### PR TITLE
Add continue() to Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add `continue()` to `Query` to allow simple initiation of continuation paging.
+
 ## 1.11.1
 
 * Fix through relationship handling, when no fields are specified this is the equivalent to returning all fields and must be honoured if a related through field is add to the browse query

--- a/lib/query.js
+++ b/lib/query.js
@@ -57,6 +57,16 @@ class Query {
   }
 
   /**
+   * Appends `continue=true` to the query to initiate continuation paging
+   *
+   * @returns {Query}
+   */
+  continue() {
+    this.query += '&continue=true';
+    return this;
+  }
+
+  /**
    * Appends `include=value1,value2` to the query
    *
    * @param {...string} includes - includes(s) (linked resources) to return in the json response

--- a/test/spec/query.js
+++ b/test/spec/query.js
@@ -55,6 +55,10 @@ describe('Query', () => {
       expect(query.count().query).toEqual('&count=true');
     });
 
+    it('"continue" should append "&continue=true" to the query', () => {
+      expect(query.continue().query).toEqual('&continue=true');
+    });
+
     it('"lang" should append "&lang=<value>" to the query', () => {
       expect(query.lang('en').query).toEqual('&lang=en');
     });


### PR DESCRIPTION
Add `continue()` to `Query` to allow simple initiation of continuation paging.