### PR TITLE
Reimplement ResourcefulEndpoint.all() to avoid Promise recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Reimplement `ResourcefulEndpoint.all()` to avoid Promise recursion memory issues.
+
 ## 1.12.0
 
 * Add `continue()` to `Query` to allow simple initiation of continuation paging.

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -151,6 +151,10 @@ class ResourceCollection {
     return this.collection.length;
   }
 
+  hasNextPage() {
+    return !!this.rawData.meta.next || !!this.rawData.meta.continue;
+  }
+
   /**
    * Fetch the next page of results
    *

--- a/lib/resource_collection.js
+++ b/lib/resource_collection.js
@@ -151,6 +151,11 @@ class ResourceCollection {
     return this.collection.length;
   }
 
+  /**
+   * Indicates whether there is next page of results available
+   *
+   * @returns true - if there is a next page
+   */
   hasNextPage() {
     return !!this.rawData.meta.next || !!this.rawData.meta.continue;
   }

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -1,5 +1,5 @@
 import Query from './query';
-import ResourceCollection, { NO_NEXT_PAGE_ERROR } from './resource_collection';
+import ResourceCollection from './resource_collection';
 import Resource from './resource';
 
 /**

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -232,42 +232,36 @@ class ResourcefulEndpoint {
    *
    * @returns {Promise} - A {@link ResourceCollection}
    */
-  all(criteria, options) {
-    let collection = null;
+  async all(criteria, options) {
     const { pluralName } = this.resourceful;
-    function accumulate(resourceCollection) {
-      if (collection === null) {
-        collection = Object.assign({}, resourceCollection);
-      } else {
-        // Things rely on rawData, not the derived collections
-        collection.rawData[pluralName] = collection.rawData[pluralName].concat(resourceCollection.rawData[pluralName]);
-        if (resourceCollection.rawData.linked) {
-          Object.entries(resourceCollection.rawData.linked).forEach(([key, value]) => {
-            if (!collection.rawData.linked[key]) collection.rawData.linked[key] = [];
-            collection.rawData.linked[key] = collection.rawData.linked[key].concat(value);
-          });
-        }
+    const rawData = {
+      meta: {},
+      [pluralName]: []
+    };
+
+    // This is to avoid memory issues caused by recursion of Promises
+    // See https://alexn.org/blog/2017/10/11/javascript-promise-leaks-memory.html
+    // And https://github.com/promises-aplus/promises-spec/issues/179
+    let collection = await this.browse(criteria, options);
+    let hasNext = collection.hasNextPage();
+    while (hasNext) {
+      // Things rely on rawData, not the derived collections
+      rawData[pluralName].push(...collection.rawData[pluralName]);
+      if (collection.rawData.linked) {
+        Object.entries(collection.rawData.linked).forEach(([key, value]) => {
+          if (!rawData.linked) rawData.linked = {};
+          if (!rawData.linked[key]) rawData.linked[key] = [];
+          rawData.linked[key].push(...value);
+        });
       }
 
-      return resourceCollection
-        .nextPage()
-        .then(c => accumulate(c))
-        .catch((err) => {
-          if (err === NO_NEXT_PAGE_ERROR) {
-            return collection;
-          }
-
-          throw err;
-        })
-        .then(() => collection);
+      // eslint-disable-next-line no-await-in-loop
+      collection = await collection.nextPage();
+      hasNext = collection.hasNextPage();
     }
 
-    return (
-      this.browse(criteria, options)
-        .then(c => accumulate(c))
-        // Return a new ResourceCollection to ensure all is ok
-        .then(c => new ResourceCollection(c.rawData, c.initialCriteria, c.resourcefulEndpoint))
-    );
+    rawData.meta.totalCount = rawData[pluralName].length;
+    return new ResourceCollection(rawData, criteria, this);
   }
 
   /**


### PR DESCRIPTION
Promise recursion is known to cause memory leaks when using the native implementation of Promises.

`.all()` relied on Promise recursion, which following the support of continuation pagination, means it's now possible to blow the JS heap very easily.