### PR TITLE
Fix a bug with .all() where it could miss the final page of results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix a bug with `ResourcefulEndpoint.all()` where it could miss the final page of results.
+
 ## 1.12.2
 
 - Fix an issue with nested queries where they would be transformed from `a.b=c` to `a[b]=c`.

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -250,7 +250,7 @@ class ResourcefulEndpoint {
     // See https://alexn.org/blog/2017/10/11/javascript-promise-leaks-memory.html
     // And https://github.com/promises-aplus/promises-spec/issues/179
     let collection = await this.browse(criteria, options);
-    let hasNext = collection.hasNextPage();
+    let hasNext = true;
     while (hasNext) {
       hasNext = collection.hasNextPage();
 

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -252,6 +252,8 @@ class ResourcefulEndpoint {
     let collection = await this.browse(criteria, options);
     let hasNext = collection.hasNextPage();
     while (hasNext) {
+      hasNext = collection.hasNextPage();
+
       // Things rely on rawData, not the derived collections
       rawData[pluralName].push(...collection.rawData[pluralName]);
       if (collection.rawData.linked) {
@@ -262,9 +264,10 @@ class ResourcefulEndpoint {
         });
       }
 
-      // eslint-disable-next-line no-await-in-loop
-      collection = await collection.nextPage();
-      hasNext = collection.hasNextPage();
+      if (hasNext) {
+        // eslint-disable-next-line no-await-in-loop
+        collection = await collection.nextPage();
+      }
     }
 
     rawData.meta.totalCount = rawData[pluralName].length;


### PR DESCRIPTION
On the final page of results, the .all() function would make the call, then set the `hasNext` value.  After fetching the final page, it would set `hasNext` to false, and this would cause the loop to not process the last request.