### PR TITLE
Pin lint-staged to 8.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10090,7 +10090,7 @@
     },
     "staged-git-files": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
       "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "jest": "^23.3.0",
     "jest-fetch-mock": "^1.6.5",
     "jsdoc": "^3.5.5",
-    "lint-staged": "^8.0.3",
+    "lint-staged": "8.0.3",
     "lodash": "^4.17.11",
     "stryker": "^0.25.1",
     "stryker-api": "^0.18.0",


### PR DESCRIPTION
Pinning `lint-staged` to 8.0.3 until https://github.com/okonet/lint-staged/issues/511 is resolved.