### PR TITLE
Allow adding custom owner to query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.14.3
+## 1.15.0
 
 - Modified `resourceful_endpoint`'s `criteriaToQuery` function to accept an owner query param in criteria.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.14.3
+
+- Modified `resourceful_endpoint`'s `criteriaToQuery` function to accept an owner query param in criteria.
+
 ## 1.14.2
 
 - Fix bug with direct relationships containing `through` fields (`filterName` is only required in `indirect` relationships).

--- a/lib/resourceful_endpoint.js
+++ b/lib/resourceful_endpoint.js
@@ -544,14 +544,17 @@ class ResourcefulEndpoint {
    * @returns {string}
    */
   criteriaToQuery(criteria) {
-    let query = `?owner=${this.owner}`;
+    let stringifiedCriteria = criteria || '';
 
-    if (typeof criteria === 'string') {
-      if (criteria !== '') {
-        query += `&${criteria}`;
-      }
-    } else if (criteria instanceof Query) {
-      query += `${criteria.toQueryString() && '&'}${criteria.toQueryString()}`;
+    if (criteria instanceof Query) {
+      stringifiedCriteria = criteria.toQueryString();
+    }
+
+    let query = `?${stringifiedCriteria}`;
+    const hasOwner = stringifiedCriteria.match(/&?owner=[^&]+/);
+
+    if (!hasOwner) {
+      query = stringifiedCriteria.length ? `?owner=${this.owner}&${stringifiedCriteria}` : `?owner=${this.owner}`;
     }
 
     return query;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Sequoia client SDK for Javascript",
   "main": "dist/web/sequoia-client.js",
   "browser": "dist/web/sequoia-client.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pikselpalette/sequoia-js-client-sdk",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "Sequoia client SDK for Javascript",
   "main": "dist/web/sequoia-client.js",
   "browser": "dist/web/sequoia-client.js",

--- a/test/spec/resourceful_endpoint.js
+++ b/test/spec/resourceful_endpoint.js
@@ -229,6 +229,12 @@ describe('ResourcefulEndpoint', () => {
       expect(resourcefulEndpoint.criteriaToQuery(query)).toMatch(new RegExp(`&${criteria}$`));
       expect(query.toQueryString).toHaveBeenCalled();
     });
+
+    it('should not append the owner if there is already one in the query', () => {
+      const criteria = 'owner=foo';
+      expect(resourcefulEndpoint.criteriaToQuery(criteria)).not.toContain('?owner=test');
+      expect(resourcefulEndpoint.criteriaToQuery(criteria)).toContain('?owner=foo');
+    });
   });
 
   describe('endPointUrl', () => {


### PR DESCRIPTION
So far, `criteriaToQuery` always added the owner configured in `resourceful_endpoint` to the query. After this change, we suppose `criteria` might have already an `owner` param.